### PR TITLE
Configurable body size

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Make sure that you have an S3-compatible storage available. We currently tested 
   uses: actions/checkout@v4
 
 - name: Turborepo Cache Server
-  uses: brunojppb/turbo-cache-server@1.0.2
+  uses: brunojppb/turbo-cache-server@1.0.3
   env:
     PORT: "8585"
     S3_ACCESS_KEY: "YOUR_S3_ACCESS_KEY"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Make sure that you have an S3-compatible storage available. We currently tested 
     # https://hostname.domain/bucket instead.
     # Defaults to "false"
     S3_USE_PATH_STYLE: false
+    # Max payload size for each cache object sent by Turborepo
+    # Defaults to 100 MB
+    # Requests larger than that, will get "HTTP 413: Entity Too Large" errors
+    MAX_PAYLOAD_SIZE_IN_MB: "100"
 ```
 
 And that is all you need to use our remote cache server for Turborepo.

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -3,6 +3,9 @@ use std::env;
 #[derive(Clone)]
 pub struct AppSettings {
     pub port: u16,
+    /// The maximum size allowed for payloads
+    /// uploaded by Turborepo. Defaults to 100MB.
+    pub max_payload_size_in_bytes: usize,
     pub s3_access_key: Option<String>,
     pub s3_secret_key: Option<String>,
     pub s3_endpoint: Option<String>,
@@ -32,8 +35,22 @@ pub fn get_settings() -> AppSettings {
     // by default,we scope Turborepo artifacts using the "TURBO_TEAM" name sent by turborepo
     // which creates a folder within the S3 bucket and uploads everything under that.
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or("turbo".to_owned());
+
+    let payload_in_mb = env::var("MAX_PAYLOAD_SIZE_IN_MB").unwrap_or("100".to_string());
+
+    let max_payload_size_in_bytes = payload_in_mb
+        .parse::<usize>()
+        .map(|size_in_mb| size_in_mb * 1024 * 1024)
+        .unwrap_or_else(|_| {
+            panic!(
+                "Invalid value given for MAX_PAYLOAD_SIZE_IN_MB: \"{}\"",
+                payload_in_mb
+            )
+        });
+
     AppSettings {
         port,
+        max_payload_size_in_bytes,
         s3_access_key,
         s3_secret_key,
         s3_region,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use std::net::TcpListener;
 
 use decay::{
     app_settings::get_settings,
-    storage::Storage,
     telemetry::{get_telemetry_subscriber, init_telemetry_subscriber},
 };
 
@@ -20,6 +19,6 @@ async fn main() -> Result<(), std::io::Error> {
     let app_settings = get_settings();
     let address = format!("127.0.0.1:{}", app_settings.port);
     let listener = TcpListener::bind(address)?;
-    let storage = Storage::new(&app_settings);
-    decay::startup::run(listener, storage)?.await
+
+    decay::startup::run(listener, app_settings)?.await
 }

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -2,7 +2,6 @@ use std::net::TcpListener;
 
 use decay::{
     app_settings::get_settings,
-    storage::Storage,
     telemetry::{get_telemetry_subscriber, init_telemetry_subscriber},
 };
 
@@ -49,8 +48,7 @@ fn spawn_app() -> TestApp {
     let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind to local address");
     let port = listener.local_addr().unwrap().port();
     let app_settings = get_settings();
-    let storage = Storage::new(&app_settings);
-    let server = decay::startup::run(listener, storage).expect("Could not bind to listener");
+    let server = decay::startup::run(listener, app_settings).expect("Could not bind to listener");
     let _ = tokio::spawn(server);
 
     let address = format!("http://127.0.0.1:{}", port);


### PR DESCRIPTION
Allow max cache size config to take larger cache objects to be stored.

It was previously capping payload sizes to 100MB so we don't accidentally upload gigabytes in a single cache file. But this can be problematic if we cannot configure this via the environment.

This PR adds support to the `MAX_PAYLOAD_SIZE_IN_MB` environment variable so users can customise it per job.