### PR TITLE
Use `LazyLock` as a replacement for `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,6 @@ dependencies = [
  "actix-web",
  "dotenv",
  "futures",
- "once_cell",
  "openssl",
  "reqwest",
  "rust-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,13 @@ tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = [
-  "registry",
-  "env-filter",
+    "registry",
+    "env-filter",
 ] }
 tracing-log = "0.2.0"
 tracing-bunyan-formatter = "0.3.9"
 futures = "0.3.30"
 openssl = { version = "0.10.66", features = ["vendored"] }
-once_cell = "1.19.0"
 
 [dev-dependencies]
 reqwest = "0.11.23"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 # let's cross-compile using musl so the binary is statically linked with the right dependencies
 # See: https://users.rust-lang.org/t/unable-to-run-compiled-program/88441/5
 # See: https://github.com/rust-cross/rust-musl-cross
-# See: https://hub.docker.com/layers/messense/rust-musl-cross/x86_64-musl/images/sha256-d3c1fbd71e737fe988bd7a141c171c8f4b5a7d072a0c84a58720fdf7cf4ded24?context=explore
-FROM messense/rust-musl-cross@sha256:9bf63830ce63649fb54995c5fbbd36b993535208000909ad4f9993bf6e168154 as builder
+# See: https://hub.docker.com/layers/messense/rust-musl-cross/x86_64-musl/images/sha256-740c62dd2e08746df5fafa3fa47f5f2b0afb231c911e8b929c584d93c3baacae?context=explore
+FROM messense/rust-musl-cross@sha256:47306f9557003a9cb1c63f5229c8276bc75e3bcf2be51e0d00f4abcc65fffaa4 as builder
 WORKDIR /app
 COPY . /app
 RUN cargo build --verbose --release

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -60,8 +60,8 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Bytes) -> 
 
             HttpResponse::Created().json(artifact)
         }
-        Err(e) => {
-            eprintln!("Something went wrong {}", e);
+        Err(error) => {
+            tracing::error!("Could not store file error={}", error);
             HttpResponse::BadRequest().finish()
         }
     }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -12,6 +12,10 @@ use crate::{
 pub fn run(listener: TcpListener, app_settings: AppSettings) -> Result<Server, std::io::Error> {
     let storage = Storage::new(&app_settings);
     let storage = web::Data::new(storage);
+    let port = listener
+        .local_addr()
+        .expect("TCPListener should be valid")
+        .port();
     let server = HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
@@ -30,7 +34,7 @@ pub fn run(listener: TcpListener, app_settings: AppSettings) -> Result<Server, s
     .listen(listener)?
     .run();
 
-    println!("Decay server started");
+    tracing::info!(port = port, "Decay server started");
 
     Ok(server)
 }

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -1,12 +1,11 @@
-use std::net::TcpListener;
-
 use decay::{
     app_settings::get_settings,
     telemetry::{get_telemetry_subscriber, init_telemetry_subscriber},
 };
 use dotenv::dotenv;
+use std::net::TcpListener;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use wiremock::MockServer;
 
 pub struct TestApp {
@@ -21,7 +20,8 @@ pub struct TestApp {
 #[allow(clippy::let_underscore_future)]
 pub async fn spawn_app() -> TestApp {
     dotenv().ok();
-    Lazy::force(&TRACING);
+
+    LazyLock::force(&TRACING);
 
     let storage_server = MockServer::start().await;
 
@@ -45,7 +45,7 @@ pub async fn spawn_app() -> TestApp {
     }
 }
 
-static TRACING: Lazy<()> = Lazy::new(|| {
+static TRACING: LazyLock<()> = LazyLock::new(|| {
     let subscriber_name = "test";
     let filter_level = String::from("debug");
 


### PR DESCRIPTION
## Description

As Rust 1.80 added Lazy constructs to the std library, we can drop the need for the `once_cell` crate.