### PR TITLE
feat: add CA SSL Certificates to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+FROM alpine:3 AS ca-certificates
+RUN apk add --no-cache ca-certificates
+
 FROM --platform=$BUILDPLATFORM rust:alpine AS chef
 WORKDIR /app
 ENV PKGCONFIG_SYSROOTDIR=/
@@ -27,6 +30,7 @@ FROM scratch
 WORKDIR /app
 ARG TARGETPLATFORM
 COPY --from=builder /app/${TARGETPLATFORM} /usr/bin/decay
+COPY --from=ca-certificates /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Allow the server to bind and be available to the local network
 ENV HOST="0.0.0.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM --platform=$BUILDPLATFORM rust:alpine AS chef
 WORKDIR /app
 ENV PKGCONFIG_SYSROOTDIR=/
-RUN apk add --no-cache musl-dev openssl-dev zig perl make
-RUN cargo install --locked cargo-zigbuild cargo-chef
-RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+RUN apk add --no-cache musl-dev openssl-dev zig perl make && \
+  cargo install --locked cargo-zigbuild cargo-chef && \
+  rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 
 FROM chef AS planner
 COPY . .


### PR DESCRIPTION
Attempt to fix #87

This adds the standard CA Certificates from Alpine to our docker image