### PR TITLE
Fix artifacts status check route response

### DIFF
--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -20,8 +20,8 @@ struct PostTeamArtifactsResponse {
 }
 
 #[derive(Serialize)]
-struct StatusResponse {
-    status: String,
+struct CacheStatus {
+    status: &'static str,
 }
 
 const EMPTY_HASHES: PostTeamArtifactsResponse = PostTeamArtifactsResponse { hashes: vec![] };

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -134,4 +134,8 @@ pub async fn artifacts_status() -> impl Responder {
         status: "enabled".to_string(),
     };
     HttpResponse::Ok().json(response)
+const DUMMY_CACHE_STATUS: CacheStatus = CacheStatus { status: "enabled" };
+
+pub async fn artifacts_status() -> impl Responder {
+    HttpResponse::Ok().json(DUMMY_CACHE_STATUS)
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -19,6 +19,11 @@ struct PostTeamArtifactsResponse {
     hashes: Vec<String>,
 }
 
+#[derive(Serialize)]
+struct StatusResponse {
+    status: String,
+}
+
 const EMPTY_HASHES: PostTeamArtifactsResponse = PostTeamArtifactsResponse { hashes: vec![] };
 
 /// As of now, we do not need to list all artifacts for a given
@@ -122,4 +127,11 @@ impl ArtifactRequest {
 
         Some(ArtifactRequest { hash, team })
     }
+}
+
+pub async fn artifacts_status() -> impl Responder {
+    let response = StatusResponse {
+        status: "enabled".to_string(),
+    };
+    HttpResponse::Ok().json(response)
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -129,11 +129,6 @@ impl ArtifactRequest {
     }
 }
 
-pub async fn artifacts_status() -> impl Responder {
-    let response = StatusResponse {
-        status: "enabled".to_string(),
-    };
-    HttpResponse::Ok().json(response)
 const DUMMY_CACHE_STATUS: CacheStatus = CacheStatus { status: "enabled" };
 
 pub async fn artifacts_status() -> impl Responder {

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,7 +10,8 @@ use crate::{
     app_settings::AppSettings,
     auth::turbo_token::validate_turbo_token,
     routes::{
-        artifacts_status, get_file, head_check_file, health_check, post_events, post_list_team_artifacts, put_file,
+        artifacts_status, get_file, head_check_file, health_check, post_events,
+        post_list_team_artifacts, put_file,
     },
     storage::Storage,
 };

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,7 +10,7 @@ use crate::{
     app_settings::AppSettings,
     auth::turbo_token::validate_turbo_token,
     routes::{
-        get_file, head_check_file, health_check, post_events, post_list_team_artifacts, put_file,
+        artifacts_status, get_file, head_check_file, health_check, post_events, post_list_team_artifacts, put_file,
     },
     storage::Storage,
 };
@@ -26,7 +26,7 @@ pub fn run(listener: TcpListener, app_settings: AppSettings) -> Result<Server, s
     let server = HttpServer::new(move || {
         let artifacts_scope = web::scope("/v8/artifacts")
             .route("", web::post().to(post_list_team_artifacts))
-            .route("/status", web::get().to(health_check))
+            .route("/status", web::get().to(artifacts_status))
             .route("/events", web::post().to(post_events))
             .route("/{hash}", web::put().to(put_file))
             .route("/{hash}", web::get().to(get_file))

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -156,7 +156,7 @@ async fn artifacts_status_test() {
         .unwrap_or_else(|_| panic!("Failed to request /v8/artifacts/status"));
 
     assert!(response.status().is_success());
-    
+
     let response_text = response.text().await.unwrap();
     assert!(response_text.contains("\"status\""));
     assert!(response_text.contains("\"enabled\""));

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -142,3 +142,22 @@ async fn mock_s3_head_req(
     .mount(&app.storage_server)
     .await;
 }
+
+#[tokio::test]
+async fn artifacts_status_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+
+    let response = client
+        .get(format!("{}/v8/artifacts/status", &app.address))
+        .send()
+        .await
+        .unwrap_or_else(|_| panic!("Failed to request /v8/artifacts/status"));
+
+    assert!(response.status().is_success());
+    
+    let response_text = response.text().await.unwrap();
+    assert!(response_text.contains("\"status\""));
+    assert!(response_text.contains("\"enabled\""));
+}

--- a/tests/e2e/health_check.rs
+++ b/tests/e2e/health_check.rs
@@ -12,15 +12,6 @@ async fn health_check_test() {
     assert_eq!(Some(0), response.content_length());
 }
 
-#[tokio::test]
-async fn turborepo_status_check_test() {
-    let app = spawn_app(None).await;
-
-    let response = check_endpoint("/v8/artifacts/status", &app).await;
-
-    assert!(response.status().is_success());
-    assert_eq!(Some(0), response.content_length());
-}
 
 async fn check_endpoint(endpoint: &str, app: &crate::helpers::TestApp) -> Response {
     let client = reqwest::Client::new();

--- a/tests/e2e/health_check.rs
+++ b/tests/e2e/health_check.rs
@@ -12,7 +12,6 @@ async fn health_check_test() {
     assert_eq!(Some(0), response.content_length());
 }
 
-
 async fn check_endpoint(endpoint: &str, app: &crate::helpers::TestApp) -> Response {
     let client = reqwest::Client::new();
 
@@ -20,5 +19,5 @@ async fn check_endpoint(endpoint: &str, app: &crate::helpers::TestApp) -> Respon
         .get(format!("{}{}", &app.address, endpoint))
         .send()
         .await
-        .unwrap_or_else(|_| panic!("Failed to request {}", endpoint))
+        .unwrap_or_else(|_| panic!("Failed to request {endpoint}"))
 }


### PR DESCRIPTION
Currently the /v8/artifacts/status route returns the empty body, but Turbo client [expects the JSON with status enum](https://turborepo.com/docs/openapi/artifacts/status). This PR updates the route to return a correctly structured data.