### PR TITLE
fix(auth): require TURBO_TOKEN at startup, add ALLOW_NO_TOKEN escape hatch

### DIFF
--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -99,7 +99,20 @@ pub fn get_settings() -> AppSettings {
     // which creates a folder within the S3 bucket and uploads everything under that.
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or("turbo".to_owned());
 
-    let turbo_token = env::var("TURBO_TOKEN").ok();
+    let turbo_token = env::var("TURBO_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty());
+
+    let allow_no_token = env::var("ALLOW_NO_TOKEN")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
+
+    if turbo_token.is_none() && !allow_no_token {
+        panic!(
+            "TURBO_TOKEN is not set. Refusing to start without authentication. \
+             Set ALLOW_NO_TOKEN=true to explicitly disable authentication (not recommended for production)."
+        );
+    }
 
     AppSettings {
         host,

--- a/src/auth/turbo_token.rs
+++ b/src/auth/turbo_token.rs
@@ -24,9 +24,9 @@ pub async fn validate_turbo_token(
             }
             return Ok(unauthrorized(req));
         }
-        (Some(_token), None) => return Ok(unauthrorized(req)),
-        _ => {
-            tracing::info!("No token provided. skipping...");
+        (Some(_), None) => return Ok(unauthrorized(req)),
+        (None, _) => {
+            // Reached only when ALLOW_NO_TOKEN=true was set at startup.
             return next.call(req).await.map(|v| v.map_into_boxed_body());
         }
     }


### PR DESCRIPTION
## Summary

- `get_settings()` now panics at startup if `TURBO_TOKEN` is absent or empty, turning a silent authentication bypass into an observable startup failure
- Added `ALLOW_NO_TOKEN=true` env var to explicitly opt out of authentication (local dev / testing)
- The `(None, _)` bypass arm in `validate_turbo_token` is now only reachable when `ALLOW_NO_TOKEN=true` was acknowledged at startup — no implicit open path remains

## Background

The previous `validate_turbo_token` middleware used a wildcard `_` match arm that called `next.call()` unconditionally whenever `TURBO_TOKEN` was not configured. `env::var("TURBO_TOKEN").ok()` yields `None` on absence rather than failing, so the server booted normally without the variable and silently skipped all authentication with a single `info`-level log line.

This is the server-side enabler of the CREEP cache-poisoning attack described in **CVE-2025-36852** (CVSS 9.4): a single unauthenticated `PUT /v8/artifacts/<hash>` request can overwrite a cached build artifact, causing every subsequent CI cache hit to execute the poisoned output.

## Test plan

- [ ] Start server without `TURBO_TOKEN` — confirm it panics with the expected message
- [ ] Start server with `ALLOW_NO_TOKEN=true` and no `TURBO_TOKEN` — confirm it boots and serves unauthenticated requests
- [ ] Start server with `TURBO_TOKEN=secret` — confirm valid `Authorization: Bearer secret` succeeds and missing/wrong token returns 401