### PR TITLE
chore(renovate): group opentelemetry crates with tracing-opentelemetry

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -6,4 +6,17 @@
     automerge: true,
     schedule: "before 5am on monday"
   },
+  packageRules: [
+    {
+      matchManagers: ["cargo"],
+      matchPackageNames: [
+        "opentelemetry",
+        "opentelemetry_sdk",
+        "opentelemetry-otlp",
+        "opentelemetry-semantic-conventions",
+        "tracing-opentelemetry"
+      ],
+      groupName: "opentelemetry"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry that groups the `opentelemetry-rust` monorepo crates (`opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `opentelemetry-semantic-conventions`) together with `tracing-opentelemetry` under a single `opentelemetry` group.
- `tracing-opentelemetry` lives in a separate repo and follows its own SemVer, but each release exists to add support for a specific `opentelemetry-rust` version — they must move in lockstep.
- Without this rule Renovate splits them into separate PRs (e.g. #549 and #554), neither of which compiles on its own.

## Test plan
- [ ] Close/rebase #549 and #554 after merging and confirm Renovate re-opens a single combined PR.
- [ ] Optional: run `npx --yes renovate-config-validator renovate.json5` locally to validate the config.