### PR TITLE
chore: bump MSRV to Rust 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "decay"
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.95"
 version = "0.0.0"
 authors = ["Bruno Paulino <hi@bpaulino.com>"]
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ RUN cargo zigbuild -r \
 
 FROM ghcr.io/rust-cross/cargo-zigbuild AS macos-builder
 WORKDIR /app
-RUN rustup target add x86_64-apple-darwin aarch64-apple-darwin
+RUN rustup update stable && rustup default stable && \
+  rustup target add x86_64-apple-darwin aarch64-apple-darwin
 COPY . .
 RUN cargo zigbuild --release --target universal2-apple-darwin && \
   cp target/universal2-apple-darwin/release/decay /app/decay-darwin-universal


### PR DESCRIPTION
## Summary
- Bump declared `rust-version` in `Cargo.toml` from 1.93 to 1.95 to track the latest stable Rust release.

## Test plan
- [x] `cargo check` succeeds locally on Rust 1.95.0
- [ ] CI passes