### PR TITLE
feat(release): publish prebuilt binaries as GitHub Release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,15 @@ jobs:
           CACHE_SERVER_VERSION: ${{ github.event.inputs.semver }}
         run: git push origin $CACHE_SERVER_VERSION
 
+      - name: Stage release binaries
+        run: |
+          mkdir -p release-assets
+          cp action/decay-x64 release-assets/decay-x86_64-unknown-linux-musl
+          cp action/decay-arm64 release-assets/decay-aarch64-unknown-linux-musl
+          cp action/decay-darwin-universal release-assets/decay-universal-apple-darwin
+          chmod +x release-assets/*
+          cd release-assets && sha256sum decay-* > SHA256SUMS
+
       - name: Create GitHub Release
         env:
           CACHE_SERVER_VERSION: ${{ github.event.inputs.semver }}
@@ -123,8 +132,27 @@ jobs:
               --pretty=format:"* %s (%h)" >> "$NOTES_FILE"
           fi
 
+          echo "" >> "$NOTES_FILE"
+          echo "" >> "$NOTES_FILE"
+          echo "## Downloads" >> "$NOTES_FILE"
+          echo "" >> "$NOTES_FILE"
+          echo "Prebuilt binaries for running \`decay\` without Docker (e.g. as a systemd service)." >> "$NOTES_FILE"
+          echo "The Linux binaries are statically linked (musl) and run on any modern x86-64/ARM64 Linux distro." >> "$NOTES_FILE"
+          echo "" >> "$NOTES_FILE"
+          echo "| Platform | Architecture | Asset |" >> "$NOTES_FILE"
+          echo "| --- | --- | --- |" >> "$NOTES_FILE"
+          echo "| Linux (musl) | x86-64 | \`decay-x86_64-unknown-linux-musl\` |" >> "$NOTES_FILE"
+          echo "| Linux (musl) | ARM64 | \`decay-aarch64-unknown-linux-musl\` |" >> "$NOTES_FILE"
+          echo "| macOS (universal) | Intel + Apple Silicon | \`decay-universal-apple-darwin\` |" >> "$NOTES_FILE"
+          echo "" >> "$NOTES_FILE"
+          echo "Verify a download against \`SHA256SUMS\`, e.g. \`sha256sum -c SHA256SUMS --ignore-missing\`." >> "$NOTES_FILE"
+
           gh release create "${CACHE_SERVER_VERSION}" \
             --title "${CACHE_SERVER_VERSION}" \
-            --notes-file "$NOTES_FILE"
+            --notes-file "$NOTES_FILE" \
+            release-assets/decay-x86_64-unknown-linux-musl \
+            release-assets/decay-aarch64-unknown-linux-musl \
+            release-assets/decay-universal-apple-darwin \
+            release-assets/SHA256SUMS
 
           rm -f "$NOTES_FILE"


### PR DESCRIPTION
## What

Attach prebuilt binaries to each GitHub Release so deployments that can't use Docker (e.g. running `decay` as a systemd service) can download them directly.

Closes #579

## Why

The release pipeline already cross-compiles binaries via `build-binaries.yml` (`cargo-zigbuild`), and the `release` job already downloads them into `action/` — but they were only committed to git and **never attached to the GitHub Release**. `gh release create` published notes only.

## How

Single-file change to the `release` job in `.github/workflows/release.yml`. No new build jobs:

1. **Stage assets** with clear target-triple names:
   - `decay-x64` → `decay-x86_64-unknown-linux-musl`
   - `decay-arm64` → `decay-aarch64-unknown-linux-musl`
   - `decay-darwin-universal` → `decay-universal-apple-darwin`
2. **Generate `SHA256SUMS`** over the three assets so downloads can be verified.
3. **Attach** the 3 binaries + `SHA256SUMS` as positional args to the existing `gh release create`.
4. **Add a "Downloads" table** to the release notes mapping platform/arch → asset.

## Notes on coverage

The issue listed `-gnu` variants too, but the existing build produces **statically linked musl** Linux binaries, which run on glibc distros as well — strictly more portable for the systemd use case, so no separate `-gnu` builds are needed. macOS ships as one universal binary (Intel + Apple Silicon), the conventional macOS distribution form.

## Verification

- `release.yml` validated as well-formed YAML.
- Staging + `sha256sum` logic dry-run locally with placeholder files: assets renamed correctly, `SHA256SUMS` generated, `sha256sum -c` passes.

Full pipeline runs on `workflow_dispatch`, so it'll be exercised on the next real release.