### PR TITLE
feat(release): link binary names to downloads in changelog table

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,10 @@ jobs:
           echo "" >> "$NOTES_FILE"
           echo "| Platform | Architecture | Asset |" >> "$NOTES_FILE"
           echo "| --- | --- | --- |" >> "$NOTES_FILE"
-          echo "| Linux (musl) | x86-64 | \`decay-x86_64-unknown-linux-musl\` |" >> "$NOTES_FILE"
-          echo "| Linux (musl) | ARM64 | \`decay-aarch64-unknown-linux-musl\` |" >> "$NOTES_FILE"
-          echo "| macOS (universal) | Intel + Apple Silicon | \`decay-universal-apple-darwin\` |" >> "$NOTES_FILE"
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${CACHE_SERVER_VERSION}"
+          echo "| Linux (musl) | x86-64 | [decay-x86_64-unknown-linux-musl](${DOWNLOAD_URL}/decay-x86_64-unknown-linux-musl) |" >> "$NOTES_FILE"
+          echo "| Linux (musl) | ARM64 | [decay-aarch64-unknown-linux-musl](${DOWNLOAD_URL}/decay-aarch64-unknown-linux-musl) |" >> "$NOTES_FILE"
+          echo "| macOS (universal) | Intel + Apple Silicon | [decay-universal-apple-darwin](${DOWNLOAD_URL}/decay-universal-apple-darwin) |" >> "$NOTES_FILE"
           echo "" >> "$NOTES_FILE"
           echo "Verify a download against \`SHA256SUMS\`, e.g. \`sha256sum -c SHA256SUMS --ignore-missing\`." >> "$NOTES_FILE"
 


### PR DESCRIPTION
## Summary
The release changelog table now links each binary name in the Asset column directly to its downloadable release asset.

Previously the Asset column showed plain binary names. Now each name is a markdown link pointing to the GitHub Release download URL, so users can click straight through to the binary.

## Changes
- Introduce a `DOWNLOAD_URL` shell variable built from the repository and release tag.
- Wrap each binary name in the Asset column as a markdown link to `{DOWNLOAD_URL}/{asset-name}`.

The asset filenames in the URLs match exactly what `gh release create` uploads, so the links resolve correctly.