### PR TITLE
Pin Rust toolchain via rust-toolchain.toml

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,10 +44,12 @@ jobs:
         run: echo "version=$(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: build binary
+        env:
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
         run: |
           docker pull --platform linux/arm64 brunojppb/turbo-cache-server-build:latest || true
           docker pull --platform linux/amd64 brunojppb/turbo-cache-server-build:latest || true
-          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --platform linux/arm64,linux/amd64 --tag brunojppb/turbo-cache-server-build:${{ inputs.version }} --push --cache-to type=registry,ref=brunojppb/turbo-cache-server-build:${{ inputs.cache-ref }} --cache-from type=registry,ref=brunojppb/turbo-cache-server-build:latest .
+          docker buildx build --build-arg RUST_VERSION="$RUST_VERSION" --platform linux/arm64,linux/amd64 --tag brunojppb/turbo-cache-server-build:${{ inputs.version }} --push --cache-to type=registry,ref=brunojppb/turbo-cache-server-build:${{ inputs.cache-ref }} --cache-from type=registry,ref=brunojppb/turbo-cache-server-build:latest .
 
       - name: create temp containers to copy binaries from
         run: |
@@ -91,8 +93,10 @@ jobs:
         run: echo "version=$(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
 
       - name: build macOS binary
+        env:
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
         run: |
-          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --target macos-builder --tag turbo-cache-macos-build --load .
+          docker buildx build --build-arg RUST_VERSION="$RUST_VERSION" --target macos-builder --tag turbo-cache-macos-build --load .
 
       - name: copy macOS binary
         run: |

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -39,11 +39,15 @@ jobs:
           username: brunojppb
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Read Rust version from rust-toolchain.toml
+        id: rust
+        run: echo "version=$(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: build binary
         run: |
           docker pull --platform linux/arm64 brunojppb/turbo-cache-server-build:latest || true
           docker pull --platform linux/amd64 brunojppb/turbo-cache-server-build:latest || true
-          docker buildx build --platform linux/arm64,linux/amd64 --tag brunojppb/turbo-cache-server-build:${{ inputs.version }} --push --cache-to type=registry,ref=brunojppb/turbo-cache-server-build:${{ inputs.cache-ref }} --cache-from type=registry,ref=brunojppb/turbo-cache-server-build:latest .
+          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --platform linux/arm64,linux/amd64 --tag brunojppb/turbo-cache-server-build:${{ inputs.version }} --push --cache-to type=registry,ref=brunojppb/turbo-cache-server-build:${{ inputs.cache-ref }} --cache-from type=registry,ref=brunojppb/turbo-cache-server-build:latest .
 
       - name: create temp containers to copy binaries from
         run: |
@@ -82,9 +86,13 @@ jobs:
         run: |
           sed -i "s/^version = \".*\"/version = \"${{ inputs.version }}\"/" Cargo.toml
 
+      - name: Read Rust version from rust-toolchain.toml
+        id: rust
+        run: echo "version=$(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: build macOS binary
         run: |
-          docker buildx build --target macos-builder --tag turbo-cache-macos-build --load .
+          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --target macos-builder --tag turbo-cache-macos-build --load .
 
       - name: copy macOS binary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      # Ensure rustfmt is installed and setup problem matcher
+      # Toolchain (channel + rustfmt/clippy) is pinned via rust-toolchain.toml
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,9 @@ jobs:
       - name: Build and push Docker image
         env:
           CACHE_SERVER_VERSION: ${{ github.event.inputs.semver }}
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
         run: |
-          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --platform linux/arm64,linux/amd64 --tag ghcr.io/brunojppb/turbo-cache-server:$CACHE_SERVER_VERSION --tag ghcr.io/brunojppb/turbo-cache-server:latest --push .
+          docker buildx build --build-arg RUST_VERSION="$RUST_VERSION" --platform linux/arm64,linux/amd64 --tag ghcr.io/brunojppb/turbo-cache-server:$CACHE_SERVER_VERSION --tag ghcr.io/brunojppb/turbo-cache-server:latest --push .
 
       - name: Commit new binary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Read Rust version from rust-toolchain.toml
+        id: rust
+        run: echo "version=$(grep -m1 '^channel' rust-toolchain.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push Docker image
         env:
           CACHE_SERVER_VERSION: ${{ github.event.inputs.semver }}
         run: |
-          docker buildx build --platform linux/arm64,linux/amd64 --tag ghcr.io/brunojppb/turbo-cache-server:$CACHE_SERVER_VERSION --tag ghcr.io/brunojppb/turbo-cache-server:latest --push .
+          docker buildx build --build-arg RUST_VERSION=${{ steps.rust.outputs.version }} --platform linux/arm64,linux/amd64 --tag ghcr.io/brunojppb/turbo-cache-server:$CACHE_SERVER_VERSION --tag ghcr.io/brunojppb/turbo-cache-server:latest --push .
 
       - name: Commit new binary
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "decay"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 version = "0.0.0"
 authors = ["Bruno Paulino <hi@bpaulino.com>"]
 license = "MIT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
+# Rust toolchain version. This is the single fallback for standalone `docker build`.
+# CI always overrides it with --build-arg RUST_VERSION read from rust-toolchain.toml,
+# which is the single source of truth for the pinned version.
+ARG RUST_VERSION=1.96.1
+
 FROM alpine:3.24.1 AS ca-certificates
 RUN apk add --no-cache ca-certificates
 
 FROM --platform=$BUILDPLATFORM rust:alpine AS chef
+ARG RUST_VERSION
 WORKDIR /app
 ENV PKGCONFIG_SYSROOTDIR=/
 RUN apk add --no-cache musl-dev openssl-dev zig perl make && \
+  rustup toolchain install ${RUST_VERSION} && rustup default ${RUST_VERSION} && \
   cargo install --locked cargo-zigbuild cargo-chef && \
   rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 
@@ -27,8 +34,9 @@ RUN cargo zigbuild -r \
   cp target/x86_64-unknown-linux-musl/release/decay /app/linux/amd64
 
 FROM ghcr.io/rust-cross/cargo-zigbuild AS macos-builder
+ARG RUST_VERSION
 WORKDIR /app
-RUN rustup update stable && rustup default stable && \
+RUN rustup toolchain install ${RUST_VERSION} && rustup default ${RUST_VERSION} && \
   rustup target add x86_64-apple-darwin aarch64-apple-darwin
 COPY . .
 RUN cargo zigbuild --release --target universal2-apple-darwin && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.1"
+components = ["rustfmt", "clippy"]

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -152,9 +152,9 @@ impl ArtifactRequest {
     }
 
     fn from(req: &HttpRequest) -> Option<Self> {
-        let hash = match req.match_info().get("hash") {
-            Some(h) => h.to_owned(),
-            None => return None,
+        let hash = {
+            let h = req.match_info().get("hash")?;
+            h.to_owned()
         };
 
         let team = extract_team_from_req(req);

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -43,8 +43,7 @@ where
     // Only output logs to a file if the runtime has given an output path
     let maybe_file_layer = match env::var("LOGS_DIRECTORY") {
         Ok(logs_dir) => {
-            let file_appender =
-                tracing_appender::rolling::never(logs_dir, format!("{}.log", &name));
+            let file_appender = tracing_appender::rolling::never(logs_dir, format!("{}.log", name));
             let file_layer = fmt::layer().with_writer(file_appender);
             Some(file_layer)
         }


### PR DESCRIPTION
## What

Pins the Rust toolchain to **1.96.1** and centralizes the version so it lives in exactly one place: `rust-toolchain.toml`.

## Why

The version was previously implicit (floating `rust:alpine` in Docker, `rustup update stable`) and the MSRV in `Cargo.toml` was drifting. This makes the toolchain reproducible across local dev, CI, and Docker builds, with a single knob to bump later.

## How it stays DRY

`rust-toolchain.toml` is the single source of truth. Everything else derives from it:

| Consumer | How it gets the version |
| --- | --- |
| Local dev | `rustup`/`cargo` read the file natively |
| CI lint/test (`ci.yml`) | `actions-rust-lang/setup-rust-toolchain` auto-detects the file — no version in the workflow |
| Docker builds (`build-binaries.yml`, `release.yml`) | a step reads the `channel` from the file → passes `--build-arg RUST_VERSION=…` |
| `Dockerfile` | `ARG RUST_VERSION` drives `rustup toolchain install`/`default` in both build stages |

## Notes

- The `Dockerfile` installs the pinned toolchain via `rustup` rather than pinning the base image tag, so the build doesn't depend on the official `rust:<version>` image being published (the standalone `rustc` release can lead the Docker image).
- Two literals remain by necessity: the `ARG RUST_VERSION` default (fallback for standalone `docker build`; CI always overrides it) and `Cargo.toml`'s `rust-version` (MSRV — a deliberately separate concept Cargo can't source from the toolchain file).
- Bumping to 1.97 later is a one-line change to `channel`.

## Verification

- Version extraction from the TOML returns `1.96.1`.
- `rustup` auto-activates 1.96.1 via the file; `cargo fmt --check` and `cargo clippy` pass.
- `docker buildx build --call check` passes; confirmed `rustup` installs the toolchain + musl target inside `rust:alpine`.