### PR TITLE
fix: stop leaking S3 credentials through tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "pretty_assertions",
  "reqwest 0.13.4",
  "rust-s3",
+ "secrecy",
  "serde",
  "sysinfo 0.39.6",
  "tokio",
@@ -2575,6 +2576,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ opentelemetry-semantic-conventions = { version = "0.32.0", features = [
 ] }
 sysinfo = "0.39"
 tonic = "0.14.2"
+secrecy = "0.10.3"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -1,3 +1,4 @@
+use secrecy::SecretString;
 use std::env;
 use std::fmt;
 use std::str::FromStr;
@@ -60,8 +61,8 @@ pub struct AppSettings {
     /// Defaults to the loopback address
     pub host: String,
     pub port: u16,
-    pub s3_access_key: Option<String>,
-    pub s3_secret_key: Option<String>,
+    pub s3_access_key: Option<SecretString>,
+    pub s3_secret_key: Option<SecretString>,
     pub s3_endpoint: Option<String>,
     /// if your S3-compatible store does not support requests
     /// like https://bucket.hostname.domain/. Setting `s3_use_path_style`
@@ -72,7 +73,7 @@ pub struct AppSettings {
     pub s3_bucket_name: String,
     /// The server-side encryption algorithm to use for the S3 bucket.
     pub s3_server_side_encryption: Option<S3ServerSideEncryption>,
-    pub turbo_token: Option<String>,
+    pub turbo_token: Option<SecretString>,
 }
 
 pub fn get_settings() -> AppSettings {
@@ -83,8 +84,8 @@ pub fn get_settings() -> AppSettings {
 
     let host = env::var("HOST").unwrap_or("127.0.0.1".to_owned());
 
-    let s3_access_key = env::var("S3_ACCESS_KEY").ok();
-    let s3_secret_key = env::var("S3_SECRET_KEY").ok();
+    let s3_access_key = env::var("S3_ACCESS_KEY").ok().map(SecretString::from);
+    let s3_secret_key = env::var("S3_SECRET_KEY").ok().map(SecretString::from);
     let s3_region = env::var("S3_REGION").unwrap_or("eu-central-1".to_owned());
     let s3_endpoint = env::var("S3_ENDPOINT").ok();
     let s3_use_path_style = env::var("S3_USE_PATH_STYLE")
@@ -99,7 +100,7 @@ pub fn get_settings() -> AppSettings {
     // which creates a folder within the S3 bucket and uploads everything under that.
     let s3_bucket_name = env::var("S3_BUCKET_NAME").unwrap_or("turbo".to_owned());
 
-    let turbo_token = env::var("TURBO_TOKEN").ok();
+    let turbo_token = env::var("TURBO_TOKEN").ok().map(SecretString::from);
 
     AppSettings {
         host,

--- a/src/auth/turbo_token.rs
+++ b/src/auth/turbo_token.rs
@@ -6,6 +6,8 @@ use actix_web::{
     web::Data,
 };
 
+use secrecy::ExposeSecret;
+
 use crate::app_settings::AppSettings;
 
 #[tracing::instrument(name = "Request Auth", skip(req, next))]
@@ -18,7 +20,7 @@ pub async fn validate_turbo_token(
 
     match (&app_settings.turbo_token, maybe_req_token) {
         (Some(token), Some(header_token)) => {
-            let token = format!("Bearer {token}");
+            let token = format!("Bearer {}", token.expose_secret());
             if token == *header_token {
                 return next.call(req).await.map(|v| v.map_into_boxed_body());
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,16 +1,27 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use s3::{Bucket, Region, creds::Credentials, request::ResponseDataStream};
+use secrecy::ExposeSecret;
 use tokio::io::AsyncRead;
 
 use crate::app_settings::{AppSettings, S3ServerSideEncryption};
 
 const SSE_HEADER: http::HeaderName = http::HeaderName::from_static("x-amz-server-side-encryption");
 
-#[derive(Debug)]
 pub struct Storage {
     bucket: Box<Bucket>,
     server_side_encryption: Option<S3ServerSideEncryption>,
+}
+
+impl fmt::Debug for Storage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Storage")
+            .field("bucket_name", &self.bucket.name)
+            .field("region", &self.bucket.region)
+            .field("server_side_encryption", &self.server_side_encryption)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Storage {
@@ -27,9 +38,14 @@ impl Storage {
         };
 
         let credentials = match (&settings.s3_access_key, &settings.s3_secret_key) {
-            (Some(access_key), Some(secret_key)) => {
-                Credentials::new(Some(access_key), Some(secret_key), None, None, None).unwrap()
-            }
+            (Some(access_key), Some(secret_key)) => Credentials::new(
+                Some(access_key.expose_secret()),
+                Some(secret_key.expose_secret()),
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
             // If your Credentials are handled via IAM policies and allow
             // your network to access S3 directly without any credentials setup
             // Then no need to setup credentials at all. Defaults should be fine
@@ -108,5 +124,36 @@ impl Storage {
     #[tracing::instrument(name = "check if S3 file exists")]
     pub async fn file_exists(&self, path: &str) -> bool {
         self.bucket.head_object(path).await.is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_with_credentials() -> AppSettings {
+        AppSettings {
+            host: "127.0.0.1".to_owned(),
+            port: 8000,
+            s3_access_key: Some("super-secret-access-key".into()),
+            s3_secret_key: Some("super-secret-secret-key".into()),
+            s3_endpoint: Some("http://localhost:9000".to_owned()),
+            s3_use_path_style: true,
+            s3_region: "eu-central-1".to_owned(),
+            s3_bucket_name: "turbo".to_owned(),
+            s3_server_side_encryption: None,
+            turbo_token: None,
+        }
+    }
+
+    /// Storage ends up in tracing spans, which record it through `Debug`.
+    #[test]
+    fn debug_output_hides_s3_credentials() {
+        let storage = Storage::new(&settings_with_credentials());
+
+        let debug_output = format!("{storage:?}");
+
+        assert!(!debug_output.contains("super-secret-access-key"));
+        assert!(!debug_output.contains("super-secret-secret-key"));
     }
 }

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -3,6 +3,7 @@ use decay::{
     telemetry::{get_telemetry_subscriber, init_telemetry_subscriber},
 };
 use dotenv::dotenv;
+use secrecy::SecretString;
 use std::net::TcpListener;
 use std::sync::LazyLock;
 
@@ -37,9 +38,9 @@ pub async fn spawn_app(config: Option<TestAppConfig>) -> TestApp {
     app_settings.s3_endpoint = Some(storage_server.uri());
     app_settings.s3_use_path_style = true;
     app_settings.s3_bucket_name.clone_from(&bucket_name);
-    app_settings.s3_access_key = Some("mock_access_key".to_owned());
-    app_settings.s3_secret_key = Some("mock_secret_key".to_owned());
-    app_settings.turbo_token = config.and_then(|v| v.turbo_token);
+    app_settings.s3_access_key = Some("mock_access_key".into());
+    app_settings.s3_secret_key = Some("mock_secret_key".into());
+    app_settings.turbo_token = config.and_then(|v| v.turbo_token).map(SecretString::from);
 
     let server = decay::startup::run(listener, app_settings).expect("Could not bind to listener");
     let _ = tokio::spawn(server);


### PR DESCRIPTION
Closes #616.

## The problem

`Storage` derived `Debug`, and `#[tracing::instrument]` records `self` through `Debug`. `s3::Bucket`'s `Debug` prints its `Credentials` in plaintext, so every instrumented call — `put S3 file stream` among them — emitted a span attribute like:

```
credentials: RwLock { data: Credentials { access_key: Some("AKIA..."), secret_key: Some("...")
```

Anyone who can read the traces could read the S3 keys.

## The fix

`Storage` gets a hand-written `Debug` that prints the bucket name, region and encryption setting, and nothing from the credentials. This is what closes the leak: the keys are copied into `s3::Credentials`, a type we don't control, so wrapping our own fields alone would not have helped.

On top of that, the settings that hold secrets — `S3_ACCESS_KEY`, `S3_SECRET_KEY` and `TURBO_TOKEN` — are now `SecretString` from [secrecy](https://docs.rs/secrecy). They print as `[REDACTED]` and are zeroed on drop, so a stray log of `AppSettings` can't print them either. Two places call `expose_secret()`, both of which need the plaintext:

- `Storage::new`, to build the `s3::Credentials`
- `validate_turbo_token`, to compare the bearer token