### PR TITLE
fix: return 500 when the S3 bucket fails

### DIFF
--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use serde::Serialize;
 use tokio_util::io::StreamReader;
 
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageError};
 
 /// When Turborepo is configured with `"signature": true` (turbo.json), the CLI
 /// computes an HMAC-SHA256 of each artifact and sends it as the `x-artifact-tag`
@@ -55,8 +55,12 @@ pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl R
     };
 
     match storage.file_exists(&artifact_info.file_path()).await {
-        true => HttpResponse::Ok().finish(),
-        false => HttpResponse::NotFound().finish(),
+        Ok(true) => HttpResponse::Ok().finish(),
+        Ok(false) => HttpResponse::NotFound().finish(),
+        Err(error) => {
+            tracing::error!(error = %error, "Could not check artifact on the bucket");
+            HttpResponse::InternalServerError().finish()
+        }
     }
 }
 
@@ -88,8 +92,8 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
             HttpResponse::Created().json(artifact)
         }
         Err(error) => {
-            tracing::error!("Could not store file error={}", error);
-            HttpResponse::BadRequest().finish()
+            tracing::error!(error = %error, "Could not store artifact on the bucket");
+            HttpResponse::InternalServerError().finish()
         }
     }
 }
@@ -107,17 +111,23 @@ pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responde
         storage.get_file(&file_path),
         storage.get_metadata(&file_path),
     );
-    let Some(response) = maybe_response else {
-        return HttpResponse::NotFound().finish();
+
+    let response = match maybe_response {
+        Ok(response) => response,
+        Err(StorageError::NotFound) => return HttpResponse::NotFound().finish(),
+        Err(error) => {
+            tracing::error!(error = %error, "Could not read artifact from the bucket");
+            return HttpResponse::InternalServerError().finish();
+        }
     };
 
     let stream = response.bytes.map(|maybe_chunk| match maybe_chunk {
         Ok(bytes) => Result::<Bytes, actix_web::error::Error>::Ok(bytes),
         Err(error) => {
             tracing::error!(error = error.to_string(), "Chunk stream error");
-            Result::<Bytes, actix_web::error::Error>::Err(actix_web::error::ErrorBadRequest(
-                "Error while streaming artifact",
-            ))
+            Result::<Bytes, actix_web::error::Error>::Err(
+                actix_web::error::ErrorInternalServerError("Error while streaming artifact"),
+            )
         }
     });
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,13 +1,48 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use s3::{Bucket, Region, creds::Credentials, request::ResponseDataStream};
+use s3::{Bucket, Region, creds::Credentials, error::S3Error, request::ResponseDataStream};
 use secrecy::ExposeSecret;
 use tokio::io::AsyncRead;
 
 use crate::app_settings::{AppSettings, S3ServerSideEncryption};
 
 const SSE_HEADER: http::HeaderName = http::HeaderName::from_static("x-amz-server-side-encryption");
+
+#[derive(Debug)]
+pub enum StorageError {
+    /// The bucket answered, but holds no object under that path.
+    NotFound,
+    /// The bucket could not be reached, or rejected the request.
+    Unreachable(S3Error),
+}
+
+impl fmt::Display for StorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no such object in the bucket"),
+            Self::Unreachable(error) => write!(f, "S3 request failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for StorageError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NotFound => None,
+            Self::Unreachable(error) => Some(error),
+        }
+    }
+}
+
+impl From<S3Error> for StorageError {
+    fn from(error: S3Error) -> Self {
+        match error {
+            S3Error::HttpFailWithBody(404, _) => Self::NotFound,
+            other => Self::Unreachable(other),
+        }
+    }
+}
 
 pub struct Storage {
     bucket: Box<Bucket>,
@@ -67,9 +102,9 @@ impl Storage {
 
     /// Streams the file from the S3 bucket
     #[tracing::instrument(name = "get S3 file")]
-    pub async fn get_file(&self, path: &str) -> Option<ResponseDataStream> {
-        let maybe_file = self.bucket.get_object_stream(path).await;
-        maybe_file.ok()
+    pub async fn get_file(&self, path: &str) -> Result<ResponseDataStream, StorageError> {
+        let file = self.bucket.get_object_stream(path).await?;
+        Ok(file)
     }
 
     /// Returns the user metadata stored on the S3 object, if present.
@@ -94,7 +129,7 @@ impl Storage {
         path: &str,
         reader: &mut R,
         metadata: Option<&HashMap<String, String>>,
-    ) -> Result<(), String>
+    ) -> Result<(), StorageError>
     where
         R: AsyncRead + Unpin,
     {
@@ -114,16 +149,20 @@ impl Storage {
             }
         }
 
-        match builder.execute_stream(reader).await {
-            Ok(_response) => Ok(()),
-            Err(e) => Err(format!("Could not upload file: {e}")),
-        }
+        builder.execute_stream(reader).await?;
+        Ok(())
     }
 
     /// Checks whether the given file path exists on the S3 bucket
     #[tracing::instrument(name = "check if S3 file exists")]
-    pub async fn file_exists(&self, path: &str) -> bool {
-        self.bucket.head_object(path).await.is_ok()
+    pub async fn file_exists(&self, path: &str) -> Result<bool, StorageError> {
+        match self.bucket.head_object(path).await {
+            Ok(_) => Ok(true),
+            Err(error) => match StorageError::from(error) {
+                StorageError::NotFound => Ok(false),
+                error => Err(error),
+            },
+        }
     }
 }
 

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -4,7 +4,7 @@ use wiremock::{
     matchers::{header, method, path},
 };
 
-use crate::helpers::{TurboArtifactFileMock, spawn_app};
+use crate::helpers::{TestAppConfig, TurboArtifactFileMock, spawn_app};
 
 #[tokio::test]
 async fn upload_artifact_to_s3_test() {
@@ -77,6 +77,118 @@ async fn upload_artifact_forwards_artifact_tag_as_s3_metadata_test() {
         .expect("Failed to PUT artifact to the cache server");
 
     assert_eq!(response.status(), 201);
+}
+
+#[tokio::test]
+async fn upload_artifact_returns_server_error_when_s3_fails_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("PUT"))
+    .respond_with(ResponseTemplate::new(403).set_body_string("<Error>AccessDenied</Error>"))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .body(file_mock.file_bytes.clone())
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 500);
+}
+
+/// The case from issue #615: nothing answers on the configured endpoint, so the
+/// request never reaches a bucket.
+#[tokio::test]
+async fn upload_artifact_returns_server_error_when_s3_is_unreachable_test() {
+    let app = spawn_app(Some(TestAppConfig {
+        s3_endpoint: Some("http://127.0.0.1:1".to_owned()),
+        ..Default::default()
+    }))
+    .await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .body(file_mock.file_bytes.clone())
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 500);
+}
+
+#[tokio::test]
+async fn download_artifact_returns_server_error_when_s3_fails_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .respond_with(ResponseTemplate::new(500).set_body_string("<Error>InternalError</Error>"))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .get(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to GET artifact from the cache server");
+
+    assert_eq!(response.status(), 500);
+}
+
+/// A cache miss must stay a 404 so Turborepo rebuilds instead of failing.
+#[tokio::test]
+async fn download_missing_artifact_returns_not_found_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .respond_with(ResponseTemplate::new(404))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .get(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to GET artifact from the cache server");
+
+    assert_eq!(response.status(), 404);
 }
 
 #[tokio::test]
@@ -223,6 +335,27 @@ async fn artifact_does_not_exist_test() {
         .expect("Failed to HEAD and check artifact from cache server");
 
     assert_eq!(response.status(), 404);
+}
+
+#[tokio::test]
+async fn artifact_check_returns_server_error_when_s3_fails_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    mock_s3_head_req(&app, &file_mock, 503).await;
+
+    let response = client
+        .head(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to HEAD and check artifact from cache server");
+
+    assert_eq!(response.status(), 500);
 }
 
 /// A head request must be performed to the S3 bucket

--- a/tests/e2e/auth.rs
+++ b/tests/e2e/auth.rs
@@ -8,6 +8,7 @@ use reqwest::header::HeaderMap;
 async fn unauthorized_when_token_header_is_missing() {
     let test_app_config = TestAppConfig {
         turbo_token: Some(String::from("turbo-token")),
+        ..Default::default()
     };
     let app = spawn_app(Some(test_app_config)).await;
 
@@ -20,6 +21,7 @@ async fn unauthorized_when_token_header_is_missing() {
 async fn unauthorized_when_token_header_is_invalid() {
     let test_app_config = TestAppConfig {
         turbo_token: Some(String::from("turbo-token")),
+        ..Default::default()
     };
     let app = spawn_app(Some(test_app_config)).await;
 
@@ -37,6 +39,7 @@ async fn unauthorized_when_token_header_is_invalid() {
 async fn authorized_when_token_header_is_valid() {
     let test_app_config = TestAppConfig {
         turbo_token: Some(String::from("valid_token")),
+        ..Default::default()
     };
     let app = spawn_app(Some(test_app_config)).await;
 

--- a/tests/e2e/helpers.rs
+++ b/tests/e2e/helpers.rs
@@ -18,8 +18,12 @@ pub struct TestApp {
     pub bucket_name: String,
 }
 
+#[derive(Default)]
 pub struct TestAppConfig {
     pub turbo_token: Option<String>,
+    /// Replaces the mock S3 endpoint. Point it at a dead address to exercise
+    /// the path where the bucket cannot be reached.
+    pub s3_endpoint: Option<String>,
 }
 
 #[allow(clippy::let_underscore_future)]
@@ -35,12 +39,14 @@ pub async fn spawn_app(config: Option<TestAppConfig>) -> TestApp {
     let mut app_settings = get_settings();
     let bucket_name = "mock_bucket".to_owned();
 
-    app_settings.s3_endpoint = Some(storage_server.uri());
+    let config = config.unwrap_or_default();
+
+    app_settings.s3_endpoint = Some(config.s3_endpoint.unwrap_or_else(|| storage_server.uri()));
     app_settings.s3_use_path_style = true;
     app_settings.s3_bucket_name.clone_from(&bucket_name);
     app_settings.s3_access_key = Some("mock_access_key".into());
     app_settings.s3_secret_key = Some("mock_secret_key".into());
-    app_settings.turbo_token = config.and_then(|v| v.turbo_token).map(SecretString::from);
+    app_settings.turbo_token = config.turbo_token.map(SecretString::from);
 
     let server = decay::startup::run(listener, app_settings).expect("Could not bind to listener");
     let _ = tokio::spawn(server);


### PR DESCRIPTION
Closes #615

When S3 is misconfigured, the server told the client it had sent a bad request. The reporter had `s3.foo.com:80` as the endpoint with no scheme, and got back a 400 on upload.

The cause: the storage layer dropped the reason a call failed. `get_file` returned `Option`, `file_exists` returned `bool`, and `put_file` mapped any error to 400. So a missing object and an unreachable bucket looked the same.

`Storage` now returns a `StorageError` with two cases: `NotFound` (S3 answered 404) and `Unreachable` (anything else). The routes map `NotFound` to 404 as before, and everything else to 500 with the S3 error logged. Mid-download stream errors also changed from 400 to 500.
