### PR TITLE
fix: preserve artifact tags in multipart uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "rust-s3"
 version = "0.37.2"
-source = "git+https://github.com/mfroembgen/rust-s3?rev=5d3234dd12069fb978568ffcd1a0d3f204fa8823#5d3234dd12069fb978568ffcd1a0d3f204fa8823"
+source = "git+https://github.com/mfroembgen/rust-s3?rev=97f98d0983d0dd5387ef451fa4cb3e3a8002c5d3#97f98d0983d0dd5387ef451fa4cb3e3a8002c5d3"
 dependencies = [
  "async-trait",
  "aws-creds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,8 +2387,7 @@ dependencies = [
 [[package]]
 name = "rust-s3"
 version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeedb13abdaa7e48d391de05b0569b37fa0a7a64a668dff6ffb2141ad0c2527e"
+source = "git+https://github.com/mfroembgen/rust-s3?rev=5d3234dd12069fb978568ffcd1a0d3f204fa8823#5d3234dd12069fb978568ffcd1a0d3f204fa8823"
 dependencies = [
  "async-trait",
  "aws-creds",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "decay"
 [dependencies]
 actix-web = "4"
 dotenv = "0.15.0"
-rust-s3 = "0.37"
+rust-s3 = { git = "https://github.com/mfroembgen/rust-s3", rev = "5d3234dd12069fb978568ffcd1a0d3f204fa8823" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "decay"
 [dependencies]
 actix-web = "4"
 dotenv = "0.15.0"
-rust-s3 = { git = "https://github.com/mfroembgen/rust-s3", rev = "5d3234dd12069fb978568ffcd1a0d3f204fa8823" }
+rust-s3 = { git = "https://github.com/mfroembgen/rust-s3", rev = "97f98d0983d0dd5387ef451fa4cb3e3a8002c5d3" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["io"] }

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use wiremock::{
     Mock, ResponseTemplate,
-    matchers::{header, method, path},
+    matchers::{header, method, path, query_param},
 };
 
 use crate::helpers::{TestAppConfig, TurboArtifactFileMock, spawn_app};
@@ -77,6 +77,84 @@ async fn upload_artifact_forwards_artifact_tag_as_s3_metadata_test() {
         .expect("Failed to PUT artifact to the cache server");
 
     assert_eq!(response.status(), 201);
+}
+
+#[tokio::test]
+async fn upload_artifact_preserves_artifact_tag_at_multipart_boundary_test() {
+    for size in [
+        s3::bucket::CHUNK_SIZE - 1,
+        s3::bucket::CHUNK_SIZE,
+        8_715_039,
+    ] {
+        assert_artifact_tag_is_forwarded_to_s3(size).await;
+    }
+}
+
+async fn assert_artifact_tag_is_forwarded_to_s3(size: usize) {
+    let app = spawn_app(None).await;
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+    let artifact_tag = "v=1:sha256:synthetic-signature";
+    let object_path = format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    );
+
+    if size < s3::bucket::CHUNK_SIZE {
+        Mock::given(path(&object_path))
+            .and(method("PUT"))
+            .and(header("x-amz-meta-x-artifact-tag", artifact_tag))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&app.storage_server)
+            .await;
+    } else {
+        let upload_id = "synthetic-upload-id";
+        let initiate_response = format!(
+            "<InitiateMultipartUploadResult><Bucket>{}</Bucket><Key>{}/{}</Key><UploadId>{upload_id}</UploadId></InitiateMultipartUploadResult>",
+            app.bucket_name, file_mock.team, file_mock.file_hash
+        );
+
+        Mock::given(path(&object_path))
+            .and(method("POST"))
+            .and(query_param("uploads", ""))
+            .and(header("x-amz-meta-x-artifact-tag", artifact_tag))
+            .respond_with(ResponseTemplate::new(200).set_body_string(initiate_response))
+            .expect(1)
+            .mount(&app.storage_server)
+            .await;
+
+        Mock::given(path(&object_path))
+            .and(method("PUT"))
+            .and(query_param("uploadId", upload_id))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", "synthetic-etag"))
+            .expect(size.div_ceil(s3::bucket::CHUNK_SIZE) as u64)
+            .mount(&app.storage_server)
+            .await;
+
+        Mock::given(path(&object_path))
+            .and(method("POST"))
+            .and(query_param("uploadId", upload_id))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&app.storage_server)
+            .await;
+    }
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .header("x-artifact-tag", artifact_tag)
+        .body(vec![33; size])
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 201, "upload size: {size}");
+    app.storage_server.verify().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- pin the exact immutable rust-s3 fix from durch/rust-s3#471
- add application-level regression coverage below, at, and above the 8 MiB multipart boundary
- keep artifact uploads streaming and preserve the existing signed-cache GET behavior

## Root cause

The storage layer already passes `x-artifact-tag` as S3 user metadata. rust-s3 0.37.2 applies those per-upload headers to single-part `PutObject`, but does not forward them to `CreateMultipartUpload` once the first chunk reaches 8 MiB. S3 metadata must be supplied during multipart initiation.

The linked rust-s3 change forwards streaming-builder headers to initiation using a request-scoped bucket clone. Existing public APIs, multipart parts/completion, bounded concurrency, error propagation, and credential-provider behavior remain unchanged.

## Verification

- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy`
- `cargo test --all-features` (11 unit tests and 18 end-to-end tests)
- `cargo build --release --locked`
- Linux ARM64 container build; the existing builder also produced both ARM64 and AMD64 Linux binaries
- Tokio and async-std rust-s3 MinIO boundary regressions

Released 4.0.13 behavior:

| Size | PUT | Stored metadata | GET `x-artifact-tag` |
| ---: | ---: | --- | --- |
| 8,388,607 | 201 | present | present |
| 8,388,608 | 201 | missing | missing |
| 8,715,039 | 201 | missing | missing |

Final scratch container against MinIO:

| Size | PUT | Stored metadata | GET `x-artifact-tag` |
| ---: | ---: | --- | --- |
| 8,388,607 | 201 | present | present |
| 8,388,608 | 201 | present | present |
| 8,715,039 | 201 | present | present |

## Dependency coordination

This draft pins the full immutable commit from durch/rust-s3#471 so it can be tested end to end. It should move to a released rust-s3 version, or another maintainer-approved immutable upstream reference, before becoming ready to merge.

Fixes #620
