### PR TITLE
fix: keep artifact tags on multipart uploads by moving to the official AWS SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.10.2",
- "sha1",
+ "sha1 0.11.0",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -105,7 +105,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
 ]
@@ -167,7 +167,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.6.5",
  "time",
  "tracing",
  "url",
@@ -229,10 +229,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -281,6 +296,49 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-config"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.5.0",
+ "sha1 0.10.7",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
 
 [[package]]
 name = "aws-creds"
@@ -332,6 +390,513 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.141.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f9420d3a2467eed22ed3635ca653653162c386a0b0f65c78189f9bd3c1379e"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums 0.65.0",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-s3-transfer-manager"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9100eec87b9d7163d129e6658ecaeb79bb5d6d01885e0d54f18c061fe2bdd08"
+dependencies = [
+ "aws-config",
+ "aws-runtime",
+ "aws-sdk-s3",
+ "aws-smithy-checksums 0.64.8",
+ "aws-smithy-dns",
+ "aws-smithy-http-client",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "crossbeam-skiplist",
+ "crossbeam-utils",
+ "fastrand",
+ "futures-util",
+ "hdrhistogram",
+ "http-body 1.1.0",
+ "libc",
+ "nix",
+ "parking_lot",
+ "path-clean",
+ "pin-project-lite",
+ "same-file",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "p256",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.64.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+dependencies = [
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
+dependencies = [
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-dns"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b2754e55e2f05ff1bb5451685656d6b117980564c63c374a824acbef7e6aba5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "hickory-resolver",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.15",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.11.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.43",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.64.0",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.5.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.5.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,7 +906,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
  "itoa",
  "matchit",
@@ -365,7 +930,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -375,10 +940,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -432,10 +1019,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bytestring"
@@ -500,6 +1103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +1142,12 @@ dependencies = [
  "proptest",
  "serde_core",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -625,6 +1240,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,11 +1259,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -655,10 +1305,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
+name = "crypto-bigint"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -672,6 +1334,21 @@ checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "deadpool"
@@ -696,6 +1373,11 @@ name = "decay"
 version = "0.0.0"
 dependencies = [
  "actix-web",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-sdk-s3-transfer-manager",
+ "bytes",
  "dotenv",
  "futures",
  "http 1.5.0",
@@ -720,6 +1402,17 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "wiremock",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -767,7 +1460,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -778,8 +1472,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -825,10 +1520,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -837,6 +1566,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -860,6 +1601,16 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1009,12 +1760,13 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1067,6 +1819,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,9 +1875,40 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hdrhistogram"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
+dependencies = [
+ "base64",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1129,12 +1923,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.5",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1169,6 +2018,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
@@ -1186,7 +2046,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1213,6 +2073,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -1223,7 +2107,7 @@ dependencies = [
  "futures-core",
  "h2 0.4.15",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1235,16 +2119,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.5.0",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.43",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1254,7 +2154,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1269,7 +2169,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1288,13 +2188,13 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.5.0",
- "http-body",
- "hyper",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1419,6 +2319,19 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1575,6 +2488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,6 +2526,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1656,6 +2588,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,6 +2619,27 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1695,6 +2665,15 @@ name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1777,6 +2756,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl"
@@ -1929,6 +2912,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +2950,21 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1982,6 +2998,22 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2027,6 +3059,15 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2107,8 +3148,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.43",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -2129,7 +3170,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -2147,7 +3188,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2202,6 +3243,15 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2292,9 +3342,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2334,10 +3384,10 @@ dependencies = [
  "futures-util",
  "h2 0.4.15",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.11.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
@@ -2345,12 +3395,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -2358,6 +3408,22 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -2398,7 +3464,7 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 1.5.0",
  "log",
  "maybe-async",
@@ -2410,7 +3476,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sysinfo 0.37.2",
  "thiserror",
  "time",
@@ -2449,6 +3515,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -2456,7 +3534,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.14",
  "subtle",
  "zeroize",
 ]
@@ -2494,10 +3572,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.43",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.14",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2512,9 +3590,19 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2576,6 +3664,30 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -2672,6 +3784,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -2690,6 +3813,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2715,6 +3849,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2753,12 +3897,38 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2878,6 +4048,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,7 +4171,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3023,11 +4199,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -3068,14 +4254,14 @@ dependencies = [
  "bytes",
  "h2 0.4.15",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.5",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -3136,7 +4322,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.5.0",
- "http-body",
+ "http-body 1.1.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -3331,10 +4517,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3353,6 +4556,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -3484,6 +4693,12 @@ checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -3719,6 +4934,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -3820,7 +5044,7 @@ dependencies = [
  "futures",
  "http 1.5.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -3842,6 +5066,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,21 +277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attohttpc"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
-dependencies = [
- "base64",
- "http 1.5.0",
- "log",
- "native-tls",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,23 +326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-creds"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3b85155d265df828f84e53886ed9e427aed979dd8a39f5b8b2162c77e142d7"
-dependencies = [
- "attohttpc",
- "home",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror",
- "time",
- "url",
-]
-
-[[package]]
 name = "aws-lc-rs"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,15 +346,6 @@ dependencies = [
  "dunce",
  "fs_extra",
  "pkg-config",
-]
-
-[[package]]
-name = "aws-region"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838b36c8dc927b6db1b6c6b8f5d05865f2213550b9e83bf92fa99ed6525472c0"
-dependencies = [
- "thiserror",
 ]
 
 [[package]]
@@ -1050,15 +1009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,19 +1069,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_str"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,26 +1091,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "convert_case"
@@ -1299,12 +1216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,19 +1291,17 @@ dependencies = [
  "bytes",
  "dotenv",
  "futures",
- "http 1.5.0",
- "openssl",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "pretty_assertions",
- "reqwest 0.13.4",
- "rust-s3",
+ "reqwest",
  "secrecy",
  "serde",
- "sysinfo 0.39.6",
+ "sysinfo",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic",
  "tracing",
@@ -1420,9 +1329,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "derive_more"
@@ -1496,15 +1402,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
 ]
 
 [[package]]
@@ -1639,21 +1536,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1869,12 +1751,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -1984,15 +1860,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2162,22 +2029,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.11.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2181,7 @@ dependencies = [
  "socket2 0.6.5",
  "widestring",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -2369,7 +2220,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2444,12 +2295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,17 +2363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,12 +2371,6 @@ dependencies = [
  "cfg-if",
  "digest 0.11.3",
 ]
-
-[[package]]
-name = "md5"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -2555,15 +2383,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minidom"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e394a0e3c7ccc2daea3dffabe82f09857b6b510cb25af87d54bf3e910ac1642d"
-dependencies = [
- "rxml",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2602,23 +2421,6 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2762,57 +2564,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2838,7 +2593,7 @@ dependencies = [
  "bytes",
  "http 1.5.0",
  "opentelemetry",
- "reqwest 0.13.4",
+ "reqwest",
 ]
 
 [[package]]
@@ -2853,7 +2608,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2902,16 +2657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list",
- "hashbrown 0.14.5",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,7 +2694,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3124,16 +2869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -3333,45 +3068,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 1.11.0",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3441,51 +3137,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeedb13abdaa7e48d391de05b0569b37fa0a7a64a668dff6ffb2141ad0c2527e"
-dependencies = [
- "async-trait",
- "aws-creds",
- "aws-region",
- "base64",
- "bytes",
- "cfg-if",
- "futures-util",
- "hex",
- "hmac 0.12.1",
- "http 1.5.0",
- "log",
- "maybe-async",
- "md5",
- "minidom",
- "percent-encoding",
- "quick-xml",
- "reqwest 0.12.28",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.9",
- "sysinfo 0.37.2",
- "thiserror",
- "time",
- "tokio",
- "tokio-stream",
- "url",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,19 +3149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3615,25 +3253,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rxml"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc94b580d0f5a6b7a2d604e597513d3c673154b52ddeccd1d5c32360d945ee"
-dependencies = [
- "bytes",
- "rxml_validation",
-]
-
-[[package]]
-name = "rxml_validation"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e80413b9a35e9d33217b3dcac04cf95f6559d15944b93887a08be5496c4a4"
-dependencies = [
- "compact_str",
-]
 
 [[package]]
 name = "ryu"
@@ -3938,12 +3557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,20 +3612,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
@@ -4023,7 +3622,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "objc2-open-directory",
- "windows 0.62.2",
+ "windows",
 ]
 
 [[package]]
@@ -4052,19 +3651,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.3",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "thiserror"
@@ -4126,15 +3712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4188,16 +3765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4226,6 +3793,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4546,12 +4114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,19 +4215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,36 +4282,14 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -4771,20 +4298,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4795,20 +4309,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4817,9 +4320,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4846,25 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -4872,8 +4359,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -4882,18 +4369,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4902,16 +4380,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4920,7 +4389,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4947,7 +4416,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4968,20 +4437,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ name = "decay"
 
 [dependencies]
 actix-web = "4"
+aws-config = "1.10"
+aws-credential-types = "1.3"
+aws-sdk-s3 = "1.141"
+aws-sdk-s3-transfer-manager = "0.2"
+bytes = "1"
 dotenv = "0.15.0"
 rust-s3 = "0.37"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ aws-sdk-s3 = "1.141"
 aws-sdk-s3-transfer-manager = "0.2"
 bytes = "1"
 dotenv = "0.15.0"
-rust-s3 = "0.37"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2"
@@ -34,8 +34,6 @@ tracing-log = "0.2"
 tracing-bunyan-formatter = "0.3"
 tracing-opentelemetry = "0.33"
 futures = "0.3"
-http = "1"
-openssl = { version = "0.10", features = ["vendored"] }
 opentelemetry = { version = "0.32" }
 opentelemetry_sdk = { version = "0.32", features = [
   "rt-tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1"
 dotenv = "0.15.0"
 rust-s3 = "0.37"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM --platform=$BUILDPLATFORM rust:alpine AS chef
 ARG RUST_VERSION
 WORKDIR /app
 ENV PKGCONFIG_SYSROOTDIR=/
-RUN apk add --no-cache musl-dev openssl-dev zig perl make && \
+RUN apk add --no-cache musl-dev openssl-dev zig perl make cmake && \
   rustup toolchain install ${RUST_VERSION} && rustup default ${RUST_VERSION} && \
   cargo install --locked cargo-zigbuild cargo-chef && \
   rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ docker run \
   ghcr.io/brunojppb/turbo-cache-server:latest
 ```
 
+## S3 Request Retries
+
+Turbo Cache Server uses the official AWS SDK for S3, which retries a
+transient 5xx error or a throttling response up to three times, with a
+backoff delay between each try. There is no environment variable for this;
+the SDK sets it. When the bucket fails or throttles requests, the error
+still reaches the caller, but only after these retries, so it arrives slower
+rather than sooner.
+
 ## Authentication
 
 Turbo Cache Server runs **without authentication by default**. This is an
@@ -404,6 +413,39 @@ You can also set a specific expiration date:
 - **Lifecycle rules apply to all objects** in the bucket. If you're using the bucket for other purposes, consider using a dedicated bucket for cache storage or add filters to your lifecycle rules.
 - **Expiration is asynchronous**: There may be a delay between the expiration date and when objects are actually removed.
 - **Versioning**: If your bucket has versioning enabled, expiration rules apply only to current object versions. You may need separate rules for noncurrent versions.
+
+### Cleaning Up Incomplete Multipart Uploads
+
+Artifacts of 8 MiB or more go to S3 as a multipart upload. If a client
+disconnects partway through one of these uploads, the parts already sent
+stay on the bucket. They cost storage even though no complete object exists.
+
+Add a lifecycle rule that removes incomplete multipart uploads after a number
+of days:
+
+```json
+{
+  "Rules": [
+    {
+      "Status": "Enabled",
+      "AbortIncompleteMultipartUpload": {
+        "DaysAfterInitiation": 7
+      }
+    }
+  ]
+}
+```
+
+Apply it the same way as the other lifecycle rules above:
+
+```shell
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket your-bucket-name \
+  --lifecycle-configuration file://lifecycle.json
+```
+
+You can add this rule to the same `lifecycle.json` file as your expiration
+rules.
 
 ## OpenTelemetry Support
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ The GitHub Action supports both **Linux** (`x64` and `arm64`) and **macOS** (`x6
             # Optional: Enable server-side encryption for stored artifacts.
             # Valid values: AES256, aws:kms, aws:kms:dsse, aws:fsx
             S3_SERVER_SIDE_ENCRYPTION: "AES256"
+            # Optional: Whether the S3 client sends CRC checksums.
+            # "when_required" (the default) keeps requests plain, which every
+            # S3-compatible store accepts. "when_supported" turns on the AWS
+            # SDK checksums. Use it only on real AWS S3.
+            S3_CHECKSUM_MODE: "when_required"
 
         # Now you can run your turborepo tasks and rely on the cache server
         # available in the background to provide previously built artifacts (cache hits)
@@ -101,6 +106,8 @@ docker run \
   -e S3_ENDPOINT=https://s3_endpoint_here \
   -e S3_REGION=eu \
   -e S3_SERVER_SIDE_ENCRYPTION=AES256 \
+  # Optional: "when_supported" turns on AWS SDK checksums. Real AWS only.
+  -e S3_CHECKSUM_MODE=when_required \
   # Optional: enables authentication. See "Authentication" below.
   -e TURBO_TOKEN=secret-turbo-token \
   -p "8000:8000" \
@@ -218,6 +225,9 @@ spec:
               value: "https://your-s3-endpoint.com"
             - name: S3_SERVER_SIDE_ENCRYPTION
               value: "AES256"
+            # Optional: "when_supported" turns on AWS SDK checksums. Real AWS only.
+            - name: S3_CHECKSUM_MODE
+              value: "when_required"
           resources:
             requests:
               memory: "128Mi"

--- a/src/app_settings.rs
+++ b/src/app_settings.rs
@@ -55,6 +55,32 @@ impl FromStr for S3ServerSideEncryption {
     }
 }
 
+/// Whether the S3 client sends and validates CRC checksums. The default keeps
+/// requests plain, because many S3-compatible stores reject the `aws-chunked`
+/// framing the checksum path uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum S3ChecksumMode {
+    #[default]
+    WhenRequired,
+    WhenSupported,
+}
+
+impl FromStr for S3ChecksumMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "when_required" => Ok(Self::WhenRequired),
+            "when_supported" => Ok(Self::WhenSupported),
+            _ => Err(format!(
+                "Invalid S3_CHECKSUM_MODE value: '{}'. \
+                 Valid values are: when_required, when_supported",
+                s
+            )),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AppSettings {
     /// Host where to bind the server to
@@ -73,6 +99,8 @@ pub struct AppSettings {
     pub s3_bucket_name: String,
     /// The server-side encryption algorithm to use for the S3 bucket.
     pub s3_server_side_encryption: Option<S3ServerSideEncryption>,
+    /// Whether the S3 client sends and validates CRC checksums.
+    pub s3_checksum_mode: S3ChecksumMode,
     pub turbo_token: Option<SecretString>,
 }
 
@@ -95,6 +123,12 @@ pub fn get_settings() -> AppSettings {
         v.parse::<S3ServerSideEncryption>()
             .expect("Invalid S3_SERVER_SIDE_ENCRYPTION value")
     });
+    let s3_checksum_mode = env::var("S3_CHECKSUM_MODE")
+        .map(|v| {
+            v.parse::<S3ChecksumMode>()
+                .expect("Invalid S3_CHECKSUM_MODE value")
+        })
+        .unwrap_or_default();
 
     // by default,we scope Turborepo artifacts using the "TURBO_TEAM" name sent by turborepo
     // which creates a folder within the S3 bucket and uploads everything under that.
@@ -112,6 +146,7 @@ pub fn get_settings() -> AppSettings {
         s3_bucket_name,
         s3_use_path_style,
         s3_server_side_encryption,
+        s3_checksum_mode,
         turbo_token,
     }
 }
@@ -183,5 +218,33 @@ mod tests {
         let encryption = S3ServerSideEncryption::Aes256;
         let s: &str = encryption.as_ref();
         assert_eq!(s, "AES256");
+    }
+
+    #[test]
+    fn parse_when_required_checksum_mode() {
+        let result = "when_required".parse::<S3ChecksumMode>();
+        assert_eq!(result, Ok(S3ChecksumMode::WhenRequired));
+    }
+
+    #[test]
+    fn parse_when_supported_checksum_mode() {
+        let result = "when_supported".parse::<S3ChecksumMode>();
+        assert_eq!(result, Ok(S3ChecksumMode::WhenSupported));
+    }
+
+    #[test]
+    fn parse_invalid_checksum_mode_returns_error() {
+        let result = "sometimes".parse::<S3ChecksumMode>();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Invalid S3_CHECKSUM_MODE value")
+        );
+    }
+
+    #[test]
+    fn checksum_mode_defaults_to_when_required() {
+        assert_eq!(S3ChecksumMode::default(), S3ChecksumMode::WhenRequired);
     }
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -6,6 +6,7 @@ use actix_web::{
 };
 use futures::StreamExt;
 use serde::Serialize;
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io::StreamReader;
 
 use crate::storage::{Storage, StorageError};
@@ -77,11 +78,21 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
         .and_then(|value| value.to_str().ok())
         .map(|tag| HashMap::from([(ARTIFACT_TAG_HEADER.to_owned(), tag.to_owned())]));
 
-    let io_stream = body.map(|chunk| chunk.map_err(std::io::Error::other));
-    let mut reader = StreamReader::new(io_stream);
+    let content_length = req
+        .headers()
+        .get(actix_web::http::header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok());
+
+    let reader = send_reader(body);
 
     match storage
-        .put_file_stream(&artifact_info.file_path(), &mut reader, metadata.as_ref())
+        .put_file_stream(
+            &artifact_info.file_path(),
+            reader,
+            content_length,
+            metadata.as_ref(),
+        )
         .await
     {
         Ok(_) => {
@@ -91,11 +102,43 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
 
             HttpResponse::Created().json(artifact)
         }
+        Err(StorageError::LengthRequired) => {
+            tracing::warn!("Artifact at or above the part size arrived without a Content-Length");
+            HttpResponse::build(actix_web::http::StatusCode::LENGTH_REQUIRED).finish()
+        }
         Err(error) => {
             tracing::error!(error = %error, "Could not store artifact on the bucket");
             HttpResponse::InternalServerError().finish()
         }
     }
+}
+
+/// Chunks in flight between the request body and the S3 upload. Bounds the
+/// bridge's memory to this many payload chunks.
+const PAYLOAD_CHANNEL_DEPTH: usize = 4;
+
+/// Bridges the request body, which is not `Send`, to a reader the AWS transfer
+/// manager accepts.
+fn send_reader(
+    mut body: Payload,
+) -> StreamReader<ReceiverStream<Result<Bytes, std::io::Error>>, Bytes> {
+    let (tx, rx) = tokio::sync::mpsc::channel(PAYLOAD_CHANNEL_DEPTH);
+
+    actix_web::rt::spawn(async move {
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(std::io::Error::other);
+            let failed = chunk.is_err();
+            // A send error means the upload dropped the reader, so stop reading.
+            if tx.send(chunk).await.is_err() {
+                break;
+            }
+            if failed {
+                break;
+            }
+        }
+    });
+
+    StreamReader::new(ReceiverStream::new(rx))
 }
 
 #[tracing::instrument(name = "Read artifact", skip(storage))]
@@ -121,7 +164,7 @@ pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responde
         }
     };
 
-    let stream = response.bytes.map(|maybe_chunk| match maybe_chunk {
+    let stream = response.map(|maybe_chunk| match maybe_chunk {
         Ok(bytes) => Result::<Bytes, actix_web::error::Error>::Ok(bytes),
         Err(error) => {
             tracing::error!(error = error.to_string(), "Chunk stream error");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -181,6 +181,7 @@ mod tests {
             s3_region: "eu-central-1".to_owned(),
             s3_bucket_name: "turbo".to_owned(),
             s3_server_side_encryption: None,
+            s3_checksum_mode: crate::app_settings::S3ChecksumMode::WhenRequired,
             turbo_token: None,
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,3 +1,5 @@
+mod client;
+
 use std::collections::HashMap;
 use std::fmt;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,29 +1,33 @@
-mod client;
-mod upload;
-
 use std::collections::HashMap;
 use std::fmt;
 
-use s3::{Bucket, Region, creds::Credentials, error::S3Error, request::ResponseDataStream};
-use secrecy::ExposeSecret;
+use bytes::Bytes;
+use futures::Stream;
 use tokio::io::AsyncRead;
 
-use crate::app_settings::{AppSettings, S3ServerSideEncryption};
+use crate::app_settings::AppSettings;
+use crate::storage::upload::{UploadError, Uploader};
 
-const SSE_HEADER: http::HeaderName = http::HeaderName::from_static("x-amz-server-side-encryption");
+mod client;
+mod upload;
 
 #[derive(Debug)]
 pub enum StorageError {
     /// The bucket answered, but holds no object under that path.
     NotFound,
+    /// The body was at or above the part size with no Content-Length.
+    LengthRequired,
     /// The bucket could not be reached, or rejected the request.
-    Unreachable(S3Error),
+    Unreachable(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl fmt::Display for StorageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NotFound => write!(f, "no such object in the bucket"),
+            Self::LengthRequired => {
+                write!(f, "uploads at or above the part size need a Content-Length")
+            }
             Self::Unreachable(error) => write!(f, "S3 request failed: {error}"),
         }
     }
@@ -32,95 +36,106 @@ impl fmt::Display for StorageError {
 impl std::error::Error for StorageError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::NotFound => None,
-            Self::Unreachable(error) => Some(error),
+            Self::NotFound | Self::LengthRequired => None,
+            Self::Unreachable(error) => Some(error.as_ref()),
         }
     }
 }
 
-impl From<S3Error> for StorageError {
-    fn from(error: S3Error) -> Self {
+impl From<UploadError> for StorageError {
+    fn from(error: UploadError) -> Self {
         match error {
-            S3Error::HttpFailWithBody(404, _) => Self::NotFound,
-            other => Self::Unreachable(other),
+            UploadError::LengthRequired => Self::LengthRequired,
+            UploadError::Failed(error) => Self::Unreachable(error),
         }
     }
 }
 
 pub struct Storage {
-    bucket: Box<Bucket>,
-    server_side_encryption: Option<S3ServerSideEncryption>,
+    s3: aws_sdk_s3::Client,
+    uploader: Uploader,
+    bucket: String,
 }
 
 impl fmt::Debug for Storage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Storage")
-            .field("bucket_name", &self.bucket.name)
-            .field("region", &self.bucket.region)
-            .field("server_side_encryption", &self.server_side_encryption)
+            .field("bucket_name", &self.bucket)
             .finish_non_exhaustive()
     }
 }
 
 impl Storage {
     pub fn new(settings: &AppSettings) -> Self {
-        let region = match &settings.s3_endpoint {
-            Some(endpoint) => Region::Custom {
-                endpoint: endpoint.clone(),
-                region: settings.s3_region.clone(),
-            },
-            None => settings
-                .s3_region
-                .parse()
-                .expect("AWS region should be present"),
-        };
-
-        let credentials = match (&settings.s3_access_key, &settings.s3_secret_key) {
-            (Some(access_key), Some(secret_key)) => Credentials::new(
-                Some(access_key.expose_secret()),
-                Some(secret_key.expose_secret()),
-                None,
-                None,
-                None,
-            )
-            .unwrap(),
-            // If your Credentials are handled via IAM policies and allow
-            // your network to access S3 directly without any credentials setup
-            // Then no need to setup credentials at all. Defaults should be fine
-            _ => Credentials::default().expect("Could not use default AWS credentials"),
-        };
-
-        let mut bucket = Bucket::new(&settings.s3_bucket_name, region, credentials)
-            .expect("Could not create a S3 bucket");
-
-        if settings.s3_use_path_style {
-            bucket.set_path_style()
-        }
+        let config = client::build_config(settings);
+        let s3 = aws_sdk_s3::Client::from_conf(config.clone().build());
+        let uploader = Uploader::new(
+            s3.clone(),
+            config,
+            settings.s3_bucket_name.clone(),
+            settings.s3_server_side_encryption,
+        );
 
         Self {
-            bucket,
-            server_side_encryption: settings.s3_server_side_encryption,
+            s3,
+            uploader,
+            bucket: settings.s3_bucket_name.clone(),
         }
     }
 
     /// Streams the file from the S3 bucket
     #[tracing::instrument(name = "get S3 file")]
-    pub async fn get_file(&self, path: &str) -> Result<ResponseDataStream, StorageError> {
-        let file = self.bucket.get_object_stream(path).await?;
-        Ok(file)
+    pub async fn get_file(
+        &self,
+        path: &str,
+    ) -> Result<impl Stream<Item = Result<Bytes, std::io::Error>> + use<>, StorageError> {
+        match self
+            .s3
+            .get_object()
+            .bucket(&self.bucket)
+            .key(Self::key(path))
+            .send()
+            .await
+        {
+            Ok(object) => Ok(tokio_util::io::ReaderStream::new(
+                object.body.into_async_read(),
+            )),
+            Err(error) => {
+                // A 404 with no XML body (S3 sends one, but the wire contract
+                // doesn't guarantee it) leaves the SDK unable to tell NoSuchKey
+                // apart from any other not-found response, so the HTTP status
+                // is checked too.
+                let not_found = error.as_service_error().is_some_and(|e| e.is_no_such_key())
+                    || error
+                        .raw_response()
+                        .is_some_and(|response| response.status().as_u16() == 404);
+
+                if not_found {
+                    Err(StorageError::NotFound)
+                } else {
+                    Err(StorageError::Unreachable(Box::new(error)))
+                }
+            }
+        }
     }
 
     /// Returns the user metadata stored on the S3 object, if present.
     #[tracing::instrument(name = "get S3 object metadata")]
     pub async fn get_metadata(&self, path: &str) -> Option<HashMap<String, String>> {
-        let (head_result, _status) = match self.bucket.head_object(path).await {
-            Ok(result) => result,
+        match self
+            .s3
+            .head_object()
+            .bucket(&self.bucket)
+            .key(Self::key(path))
+            .send()
+            .await
+        {
+            Ok(head) => head.metadata,
             Err(error) => {
                 tracing::warn!(error = %error, path, "HEAD request failed, omitting object metadata");
-                return None;
+                None
             }
-        };
-        head_result.metadata
+        }
     }
 
     /// Streams the given data to the S3 bucket under the given path.
@@ -130,42 +145,45 @@ impl Storage {
     pub async fn put_file_stream<R>(
         &self,
         path: &str,
-        reader: &mut R,
+        reader: R,
+        content_length: Option<u64>,
         metadata: Option<&HashMap<String, String>>,
     ) -> Result<(), StorageError>
     where
-        R: AsyncRead + Unpin,
+        R: AsyncRead + Send + Sync + Unpin + 'static,
     {
-        let mut builder = self.bucket.put_object_stream_builder(path);
-
-        if let Some(encryption) = self.server_side_encryption {
-            builder = builder
-                .with_header(SSE_HEADER, encryption.as_str())
-                .expect("Invalid server-side encryption header value");
-        }
-
-        if let Some(metadata) = metadata {
-            for (key, value) in metadata {
-                builder = builder
-                    .with_metadata(key, value)
-                    .expect("Invalid metadata value");
-            }
-        }
-
-        builder.execute_stream(reader).await?;
+        self.uploader
+            .put(Self::key(path), reader, content_length, metadata)
+            .await?;
         Ok(())
     }
 
     /// Checks whether the given file path exists on the S3 bucket
     #[tracing::instrument(name = "check if S3 file exists")]
     pub async fn file_exists(&self, path: &str) -> Result<bool, StorageError> {
-        match self.bucket.head_object(path).await {
+        match self
+            .s3
+            .head_object()
+            .bucket(&self.bucket)
+            .key(Self::key(path))
+            .send()
+            .await
+        {
             Ok(_) => Ok(true),
-            Err(error) => match StorageError::from(error) {
-                StorageError::NotFound => Ok(false),
-                error => Err(error),
-            },
+            Err(error) => {
+                if error.as_service_error().is_some_and(|e| e.is_not_found()) {
+                    Ok(false)
+                } else {
+                    Err(StorageError::Unreachable(Box::new(error)))
+                }
+            }
         }
+    }
+
+    /// S3 keys hold no leading slash; callers pass file paths that do, as a
+    /// holdover from the previous S3 client's URL convention.
+    fn key(path: &str) -> &str {
+        path.trim_start_matches('/')
     }
 }
 
@@ -198,5 +216,17 @@ mod tests {
 
         assert!(!debug_output.contains("super-secret-access-key"));
         assert!(!debug_output.contains("super-secret-secret-key"));
+    }
+
+    /// Storage ends up in tracing spans, which record it through `Debug`.
+    #[test]
+    fn debug_output_hides_s3_credentials_after_the_sdk_swap() {
+        let storage = Storage::new(&settings_with_credentials());
+
+        let debug_output = format!("{storage:?}");
+
+        assert!(!debug_output.contains("super-secret-access-key"));
+        assert!(!debug_output.contains("super-secret-secret-key"));
+        assert!(debug_output.contains("turbo"), "bucket name should show");
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,5 @@
 mod client;
+mod upload;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/storage/client.rs
+++ b/src/storage/client.rs
@@ -1,6 +1,3 @@
-// Wired into `Storage` when the read path moves to the AWS SDK.
-#![allow(dead_code)]
-
 use aws_credential_types::provider::{ProvideCredentials, future};
 use aws_sdk_s3::config::{
     BehaviorVersion, Credentials, Region, RequestChecksumCalculation, ResponseChecksumValidation,

--- a/src/storage/client.rs
+++ b/src/storage/client.rs
@@ -1,0 +1,160 @@
+// Wired into `Storage` when the read path moves to the AWS SDK.
+#![allow(dead_code)]
+
+use aws_credential_types::provider::{ProvideCredentials, future};
+use aws_sdk_s3::config::{
+    BehaviorVersion, Credentials, Region, RequestChecksumCalculation, ResponseChecksumValidation,
+};
+use secrecy::ExposeSecret;
+use tokio::sync::OnceCell;
+
+use crate::app_settings::{AppSettings, S3ChecksumMode};
+
+/// Builds the default credential chain on first use, so client construction
+/// stays synchronous and the server starts even when instance metadata is
+/// briefly unreachable.
+#[derive(Debug)]
+struct LazyDefaultCredentials {
+    region: Region,
+    chain: OnceCell<aws_config::default_provider::credentials::DefaultCredentialsChain>,
+}
+
+impl ProvideCredentials for LazyDefaultCredentials {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(async move {
+            self.chain
+                .get_or_init(|| async {
+                    aws_config::default_provider::credentials::DefaultCredentialsChain::builder()
+                        .region(self.region.clone())
+                        .build()
+                        .await
+                })
+                .await
+                .provide_credentials()
+                .await
+        })
+    }
+}
+
+/// Builds the S3 configuration shared by the plain client and the transfer
+/// manager.
+pub(crate) fn build_config(settings: &AppSettings) -> aws_sdk_s3::config::Builder {
+    let region = Region::new(settings.s3_region.clone());
+
+    let (request_checksums, response_checksums) = match settings.s3_checksum_mode {
+        S3ChecksumMode::WhenRequired => (
+            RequestChecksumCalculation::WhenRequired,
+            ResponseChecksumValidation::WhenRequired,
+        ),
+        S3ChecksumMode::WhenSupported => (
+            RequestChecksumCalculation::WhenSupported,
+            ResponseChecksumValidation::WhenSupported,
+        ),
+    };
+
+    let mut config = aws_sdk_s3::Config::builder()
+        .behavior_version(BehaviorVersion::latest())
+        .region(region.clone())
+        .force_path_style(settings.s3_use_path_style)
+        .request_checksum_calculation(request_checksums)
+        .response_checksum_validation(response_checksums);
+
+    if let Some(endpoint) = &settings.s3_endpoint {
+        config = config.endpoint_url(endpoint);
+    }
+
+    match (&settings.s3_access_key, &settings.s3_secret_key) {
+        (Some(access_key), Some(secret_key)) => config.credentials_provider(Credentials::new(
+            access_key.expose_secret(),
+            secret_key.expose_secret(),
+            None,
+            None,
+            "turbo-cache-server",
+        )),
+        // Credentials handled by IAM: instance metadata, IRSA, or a profile.
+        _ => config.credentials_provider(LazyDefaultCredentials {
+            region,
+            chain: OnceCell::new(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_settings::{AppSettings, S3ChecksumMode};
+
+    fn settings() -> AppSettings {
+        AppSettings {
+            host: "127.0.0.1".to_owned(),
+            port: 8000,
+            s3_access_key: Some("access".into()),
+            s3_secret_key: Some("secret".into()),
+            s3_endpoint: Some("http://127.0.0.1:1".to_owned()),
+            s3_use_path_style: true,
+            s3_region: "eu-central-1".to_owned(),
+            s3_bucket_name: "turbo".to_owned(),
+            s3_server_side_encryption: None,
+            s3_checksum_mode: S3ChecksumMode::WhenRequired,
+            turbo_token: None,
+        }
+    }
+
+    #[test]
+    fn when_required_is_the_default_checksum_behavior() {
+        let config = build_config(&settings()).build();
+
+        assert_eq!(
+            config.request_checksum_calculation(),
+            Some(&RequestChecksumCalculation::WhenRequired)
+        );
+        assert_eq!(
+            config.response_checksum_validation(),
+            Some(&ResponseChecksumValidation::WhenRequired)
+        );
+    }
+
+    #[test]
+    fn when_supported_opts_into_checksums() {
+        let mut settings = settings();
+        settings.s3_checksum_mode = S3ChecksumMode::WhenSupported;
+
+        let config = build_config(&settings).build();
+
+        assert_eq!(
+            config.request_checksum_calculation(),
+            Some(&RequestChecksumCalculation::WhenSupported)
+        );
+    }
+
+    /// A hand-built config must resolve an HTTP client and a sleep impl from the
+    /// enabled features, or the SDK panics on the first request instead of
+    /// returning an error.
+    #[tokio::test]
+    async fn a_hand_built_config_can_send_a_request() {
+        let client = aws_sdk_s3::Client::from_conf(build_config(&settings()).build());
+
+        // Port 1 refuses connections, so this exercises the request path.
+        let result = client
+            .head_object()
+            .bucket("turbo")
+            .key("missing")
+            .send()
+            .await;
+
+        assert!(result.is_err(), "expected a dispatch error, not a panic");
+    }
+
+    #[test]
+    fn missing_credentials_fall_back_to_the_default_chain() {
+        let mut settings = settings();
+        settings.s3_access_key = None;
+        settings.s3_secret_key = None;
+
+        // Building must not panic and must not block on credential lookup.
+        let _ = build_config(&settings).build();
+    }
+}

--- a/src/storage/upload.rs
+++ b/src/storage/upload.rs
@@ -20,8 +20,10 @@ pub(crate) const PART_SIZE: u64 = 8 * 1024 * 1024;
 /// 32 MiB.
 const PARTS_IN_FLIGHT: usize = 4;
 
-/// Ceiling on buffered transfer data across all uploads. The transfer manager
-/// otherwise reserves a share of detected RAM, which is wrong for a CI container.
+/// Ceiling on part data the transfer manager buffers for multipart uploads.
+/// The transfer manager otherwise reserves a share of detected RAM, which is
+/// wrong for a CI container. The per-request head buffer (up to PART_SIZE) is
+/// separate and additional, since it fills before the size decision runs.
 const MEMORY_BUDGET: usize = 128 * 1024 * 1024;
 
 #[derive(Debug)]

--- a/src/storage/upload.rs
+++ b/src/storage/upload.rs
@@ -1,6 +1,3 @@
-// Wired into `Storage` when the read path moves to the AWS SDK.
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::fmt;
 use std::io::Cursor;

--- a/src/storage/upload.rs
+++ b/src/storage/upload.rs
@@ -1,0 +1,374 @@
+// Wired into `Storage` when the read path moves to the AWS SDK.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fmt;
+use std::io::Cursor;
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::ServerSideEncryption;
+use aws_sdk_s3_transfer_manager as transfer_manager;
+use tokio::io::{AsyncRead, AsyncReadExt};
+use transfer_manager::io::adapters::TokioIo;
+use transfer_manager::io::{InputStream, SizeHint};
+use transfer_manager::types::{ConcurrencyMode, MemoryBudgetConfig, PartSize};
+
+use crate::app_settings::S3ServerSideEncryption;
+
+/// Bodies below this size go out as a single PutObject. At or above it, the
+/// transfer manager runs a multipart upload.
+pub(crate) const PART_SIZE: u64 = 8 * 1024 * 1024;
+
+/// Parts held in memory per upload. With PART_SIZE that caps one upload at
+/// 32 MiB.
+const PARTS_IN_FLIGHT: usize = 4;
+
+/// Ceiling on buffered transfer data across all uploads. The transfer manager
+/// otherwise reserves a share of detected RAM, which is wrong for a CI container.
+const MEMORY_BUDGET: usize = 128 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(crate) enum UploadError {
+    /// A body at or above PART_SIZE arrived without a Content-Length, so the
+    /// transfer manager cannot be told the size it needs up front.
+    LengthRequired,
+    Failed(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl fmt::Display for UploadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LengthRequired => {
+                write!(f, "uploads at or above the part size need a Content-Length")
+            }
+            Self::Failed(error) => write!(f, "S3 upload failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for UploadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::LengthRequired => None,
+            Self::Failed(error) => Some(error.as_ref()),
+        }
+    }
+}
+
+pub(crate) struct Uploader {
+    s3: aws_sdk_s3::Client,
+    transfer: transfer_manager::Client,
+    bucket: String,
+    server_side_encryption: Option<S3ServerSideEncryption>,
+}
+
+impl Uploader {
+    pub(crate) fn new(
+        s3: aws_sdk_s3::Client,
+        config: aws_sdk_s3::config::Builder,
+        bucket: String,
+        server_side_encryption: Option<S3ServerSideEncryption>,
+    ) -> Self {
+        let transfer = transfer_manager::Client::new(
+            transfer_manager::Config::builder()
+                .s3_config(transfer_manager::config::S3ClientConfig::new(config))
+                .part_size(PartSize::Target(PART_SIZE))
+                .concurrency(ConcurrencyMode::Explicit(PARTS_IN_FLIGHT))
+                .memory_budget(MemoryBudgetConfig::Limit(MEMORY_BUDGET))
+                .build(),
+        );
+
+        Self {
+            s3,
+            transfer,
+            bucket,
+            server_side_encryption,
+        }
+    }
+
+    fn encryption(&self) -> Option<ServerSideEncryption> {
+        self.server_side_encryption
+            .map(|encryption| ServerSideEncryption::from(encryption.as_str()))
+    }
+
+    /// Streams the body to the bucket, keeping `metadata` as S3 user metadata.
+    pub(crate) async fn put<R>(
+        &self,
+        path: &str,
+        reader: R,
+        content_length: Option<u64>,
+        metadata: Option<&HashMap<String, String>>,
+    ) -> Result<(), UploadError>
+    where
+        R: AsyncRead + Send + Sync + Unpin + 'static,
+    {
+        let mut reader = reader;
+        let mut head = Vec::new();
+        (&mut reader)
+            .take(PART_SIZE)
+            .read_to_end(&mut head)
+            .await
+            .map_err(|error| UploadError::Failed(Box::new(error)))?;
+
+        if (head.len() as u64) < PART_SIZE {
+            self.s3
+                .put_object()
+                .bucket(&self.bucket)
+                .key(path)
+                .set_metadata(metadata.cloned())
+                .set_server_side_encryption(self.encryption())
+                .body(ByteStream::from(head))
+                .send()
+                .await
+                .map_err(|error| UploadError::Failed(Box::new(error)))?;
+
+            return Ok(());
+        }
+
+        let length = content_length.ok_or(UploadError::LengthRequired)?;
+        // Replays the bytes already read, then continues with the rest.
+        let body = Cursor::new(head).chain(reader);
+        let stream = InputStream::from_part_stream(TokioIo::new(body, SizeHint::exact(length)));
+
+        self.transfer
+            .upload()
+            .bucket(&self.bucket)
+            .key(path)
+            .set_metadata(metadata.cloned())
+            .set_server_side_encryption(self.encryption())
+            .body(stream)
+            .initiate()
+            .map_err(|error| UploadError::Failed(Box::new(error)))?
+            .join()
+            .await
+            .map_err(|error| UploadError::Failed(Box::new(error)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_settings::{AppSettings, S3ChecksumMode};
+    use wiremock::matchers::{any, method, path, query_param};
+    use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+    const TAG: &str = "v=1:sha256:abc123";
+
+    fn uploader(endpoint: &str) -> Uploader {
+        let settings = AppSettings {
+            host: "127.0.0.1".to_owned(),
+            port: 8000,
+            s3_access_key: Some("access".into()),
+            s3_secret_key: Some("secret".into()),
+            s3_endpoint: Some(endpoint.to_owned()),
+            s3_use_path_style: true,
+            s3_region: "eu-central-1".to_owned(),
+            s3_bucket_name: "turbo".to_owned(),
+            s3_server_side_encryption: None,
+            s3_checksum_mode: S3ChecksumMode::WhenRequired,
+            turbo_token: None,
+        };
+
+        let config = super::super::client::build_config(&settings);
+        let s3 = aws_sdk_s3::Client::from_conf(config.clone().build());
+
+        Uploader::new(s3, config, "turbo".to_owned(), None)
+    }
+
+    fn tag_metadata() -> HashMap<String, String> {
+        HashMap::from([("x-artifact-tag".to_owned(), TAG.to_owned())])
+    }
+
+    async fn upload(
+        server: &MockServer,
+        size: usize,
+        send_length: bool,
+    ) -> Result<(), UploadError> {
+        let reader = std::io::Cursor::new(vec![7u8; size]);
+        let length = if send_length { Some(size as u64) } else { None };
+
+        uploader(&server.uri())
+            .put("team/hash", reader, length, Some(&tag_metadata()))
+            .await
+    }
+
+    fn header(request: &Request, name: &str) -> Option<String> {
+        request
+            .headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.to_owned())
+    }
+
+    async fn mount_single_part(server: &MockServer) {
+        Mock::given(method("PUT"))
+            .and(path("/turbo/team/hash"))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"etag-single\""))
+            .mount(server)
+            .await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(server)
+            .await;
+    }
+
+    async fn mount_multipart(server: &MockServer) {
+        Mock::given(method("POST"))
+            .and(path("/turbo/team/hash"))
+            .and(query_param("uploads", ""))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult><Bucket>turbo</Bucket><Key>team/hash</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>"#,
+                "application/xml",
+            ))
+            .mount(server)
+            .await;
+
+        Mock::given(method("PUT"))
+            .and(path("/turbo/team/hash"))
+            .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"etag-part\""))
+            .mount(server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/turbo/team/hash"))
+            .and(query_param("uploadId", "upload-1"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult><Location>http://localhost/turbo/team/hash</Location><Bucket>turbo</Bucket><Key>team/hash</Key><ETag>"etag-complete"</ETag></CompleteMultipartUploadResult>"#,
+                "application/xml",
+            ))
+            .mount(server)
+            .await;
+
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(500))
+            .mount(server)
+            .await;
+    }
+
+    /// The shape the existing e2e suite asserts: one PUT carrying the raw body.
+    #[tokio::test]
+    async fn tiny_upload_stays_a_single_put_object() {
+        let server = MockServer::start().await;
+        mount_single_part(&server).await;
+
+        upload(&server, 12, true).await.expect("upload failed");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].method.as_str(), "PUT");
+        assert_eq!(
+            header(&requests[0], "x-amz-meta-x-artifact-tag").as_deref(),
+            Some(TAG)
+        );
+        assert_eq!(requests[0].body, vec![7u8; 12], "body must be sent raw");
+    }
+
+    /// 8,388,607 bytes: the size that already worked.
+    #[tokio::test]
+    async fn one_byte_below_the_part_size_stays_a_single_put_object() {
+        let server = MockServer::start().await;
+        mount_single_part(&server).await;
+
+        upload(&server, (PART_SIZE - 1) as usize, true)
+            .await
+            .expect("upload failed");
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].body.len(), (PART_SIZE - 1) as usize);
+    }
+
+    /// 8,388,608 bytes: the size that lost the tag in issue #620.
+    #[tokio::test]
+    async fn exactly_the_part_size_carries_the_tag_into_multipart() {
+        let server = MockServer::start().await;
+        mount_multipart(&server).await;
+
+        upload(&server, PART_SIZE as usize, true)
+            .await
+            .expect("upload failed");
+
+        let requests = server.received_requests().await.unwrap();
+        let initiate = requests
+            .iter()
+            .find(|r| r.method.as_str() == "POST" && r.url.query() == Some("uploads"))
+            .expect("no CreateMultipartUpload request");
+
+        assert_eq!(
+            header(initiate, "x-amz-meta-x-artifact-tag").as_deref(),
+            Some(TAG),
+            "issue #620: the tag must be set when the multipart upload starts"
+        );
+
+        let uploaded: usize = requests
+            .iter()
+            .filter(|r| r.method.as_str() == "PUT")
+            .map(|r| r.body.len())
+            .sum();
+        assert_eq!(uploaded, PART_SIZE as usize, "all bytes must reach S3");
+    }
+
+    /// 8,715,039 bytes: the third size in the issue report.
+    #[tokio::test]
+    async fn above_the_part_size_carries_the_tag_and_completes() {
+        let server = MockServer::start().await;
+        mount_multipart(&server).await;
+
+        upload(&server, 8_715_039, true)
+            .await
+            .expect("upload failed");
+
+        let requests = server.received_requests().await.unwrap();
+        let initiate = requests
+            .iter()
+            .find(|r| r.method.as_str() == "POST" && r.url.query() == Some("uploads"))
+            .expect("no CreateMultipartUpload request");
+        assert_eq!(
+            header(initiate, "x-amz-meta-x-artifact-tag").as_deref(),
+            Some(TAG)
+        );
+
+        let uploaded: usize = requests
+            .iter()
+            .filter(|r| r.method.as_str() == "PUT")
+            .map(|r| r.body.len())
+            .sum();
+        assert_eq!(uploaded, 8_715_039);
+
+        assert!(
+            requests
+                .iter()
+                .any(|r| r.method.as_str() == "POST" && r.url.query() == Some("uploadId=upload-1")),
+            "expected CompleteMultipartUpload"
+        );
+    }
+
+    /// A small body needs no Content-Length, because it never goes multipart.
+    #[tokio::test]
+    async fn small_upload_without_content_length_succeeds() {
+        let server = MockServer::start().await;
+        mount_single_part(&server).await;
+
+        upload(&server, 12, false).await.expect("upload failed");
+
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn large_upload_without_content_length_is_length_required() {
+        let server = MockServer::start().await;
+        mount_multipart(&server).await;
+
+        let result = upload(&server, PART_SIZE as usize, false).await;
+
+        assert!(matches!(result, Err(UploadError::LengthRequired)));
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "must fail before touching S3"
+        );
+    }
+}

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use wiremock::{
     Mock, ResponseTemplate,
-    matchers::{header, method, path},
+    matchers::{header, method, path, query_param},
 };
 
 use crate::helpers::{TestAppConfig, TurboArtifactFileMock, spawn_app};
@@ -392,4 +392,140 @@ async fn artifacts_status_test() {
     let response_text = response.text().await.unwrap();
     assert!(response_text.contains("\"status\""));
     assert!(response_text.contains("\"enabled\""));
+}
+
+/// Issue #620: at 8 MiB the upload becomes multipart, and S3 accepts user
+/// metadata only when the multipart upload starts. Signed caches break without
+/// it, because the client cannot verify the artifact it downloads.
+#[tokio::test]
+async fn upload_at_the_multipart_boundary_sets_metadata_on_initiation_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+    let artifact_tag = "v=1:sha256:abc123";
+    let object_path = format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    );
+
+    Mock::given(path(object_path.clone()))
+        .and(method("POST"))
+        .and(query_param("uploads", ""))
+        .and(header("x-amz-meta-x-artifact-tag", artifact_tag))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>"#,
+            "application/xml",
+        ))
+        .mount(&app.storage_server)
+        .await;
+
+    Mock::given(path(object_path.clone()))
+        .and(method("PUT"))
+        .respond_with(ResponseTemplate::new(200).insert_header("ETag", "\"etag-part\""))
+        .mount(&app.storage_server)
+        .await;
+
+    Mock::given(path(object_path))
+        .and(method("POST"))
+        .and(query_param("uploadId", "upload-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult><ETag>"etag-complete"</ETag></CompleteMultipartUploadResult>"#,
+            "application/xml",
+        ))
+        .mount(&app.storage_server)
+        .await;
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .header("x-artifact-tag", artifact_tag)
+        .body(vec![7u8; 8 * 1024 * 1024])
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 201);
+}
+
+/// A body at the multipart boundary cannot be sized without a Content-Length,
+/// so the server says so rather than guessing or buffering it all.
+///
+/// `reqwest` only builds an unsized streaming body behind its `stream`
+/// feature, which this crate does not enable, so the request is written by
+/// hand over a raw TCP socket with `Transfer-Encoding: chunked` and no
+/// `Content-Length` header — the same wire shape an HTTP/1.1 client without a
+/// known body size would send.
+#[tokio::test]
+async fn upload_at_the_multipart_boundary_without_content_length_is_rejected_test() {
+    let app = spawn_app(None).await;
+
+    let file_mock = TurboArtifactFileMock::new();
+    let host = app
+        .address
+        .strip_prefix("http://")
+        .expect("app address must be an http URL")
+        .to_owned();
+    let request_line = format!(
+        "PUT /v8/artifacts/{}?slug={} HTTP/1.1\r\n",
+        file_mock.file_hash, file_mock.team
+    );
+
+    let status = tokio::task::spawn_blocking(move || {
+        put_chunked_body_without_content_length(&host, &request_line, 8 * 1024 * 1024)
+    })
+    .await
+    .expect("the blocking socket task panicked");
+
+    assert_eq!(status, 411);
+    assert!(
+        app.storage_server
+            .received_requests()
+            .await
+            .unwrap()
+            .is_empty(),
+        "the server must not call S3 for an unsized body"
+    );
+}
+
+/// Sends `PUT {request_line}` with a single chunked-encoded body of
+/// `body_len` bytes and no `Content-Length` header, then returns the response
+/// status code. The trailing chunk framing is written best-effort, because the
+/// server may answer and close the connection as soon as it has read enough
+/// of the body to decide, before the framing completes.
+fn put_chunked_body_without_content_length(host: &str, request_line: &str, body_len: usize) -> u16 {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpStream;
+
+    let mut stream = TcpStream::connect(host).expect("Failed to connect to the cache server");
+
+    let headers = format!(
+        "{request_line}Host: {host}\r\nContent-Type: application/octet-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(headers.as_bytes())
+        .expect("Failed to write request headers");
+    stream
+        .write_all(format!("{body_len:x}\r\n").as_bytes())
+        .expect("Failed to write chunk size");
+    stream
+        .write_all(&vec![7u8; body_len])
+        .expect("Failed to write chunk body");
+    let _ = stream.write_all(b"\r\n0\r\n\r\n");
+
+    let mut status_line = String::new();
+    BufReader::new(stream)
+        .read_line(&mut status_line)
+        .expect("Failed to read the response status line");
+
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|code| code.parse().ok())
+        .expect("Failed to parse the HTTP status code")
 }


### PR DESCRIPTION
## Summary

- replace `rust-s3` with the official AWS SDK (`aws-sdk-s3` + `aws-sdk-s3-transfer-manager`)
- keep the `x-artifact-tag` on artifacts of 8 MiB and above, which fixes #620
- keep uploads streaming, with at most one 8 MiB part held in memory
- keep every existing end-to-end test unchanged, so the old wire behaviour is still proven

Fixes #620. This is an alternative to #621, which pinned an unreleased `rust-s3`
commit. The upstream fix ([durch/rust-s3#471](https://github.com/durch/rust-s3/pull/471))
is still open, and the last `rust-s3` release was 0.37.2 on 2026-05-04.

## Root cause

S3 accepts user metadata only when a multipart upload starts, on
`CreateMultipartUpload`. It cannot be added by later `UploadPart` calls.

`rust-s3` 0.37.2 hides that call inside `put_object_stream_builder`. It applies
the builder headers to a single-part `PutObject`, but drops them when the first
chunk reaches 8 MiB and it switches to multipart. So the tag survived at
8,388,607 bytes and disappeared at 8,388,608.

The official SDK exposes the call directly, with `metadata` as a first-class
parameter, so nothing is hidden and nothing is dropped.

## How uploads work now

`src/storage/upload.rs` reads up to one part size, then decides:

| Body size | Path | Requests |
| --- | --- | --- |
| under 8 MiB | `PutObject` with `.metadata()` | one raw `PUT` |
| 8 MiB and above | transfer manager, metadata on `CreateMultipartUpload` | initiate, parts, complete |

That split is deliberate. In `aws-sdk-s3-transfer-manager` 0.2.0,
`is_mpu_only()` (`io/stream.rs:155`) returns true for any stream input, and
`operation/upload/transfer.rs:191` reads it before it compares
`multipart_threshold`. Handing the transfer manager a stream therefore starts a
multipart upload at any size, so a 12-byte artifact would cost three requests
instead of one and the existing tests asserting a single raw `PUT` would fail.

`Cursor::new(head).chain(reader)` replays the buffered prefix, so no byte is
read twice and nothing beyond one part is held.

## Other behaviour worth knowing

**Bodies over 8 MiB with no `Content-Length` get `411`.** The transfer manager
rejects an upload whose size hint has no upper bound
(`operation/upload.rs:81`). Turborepo always sends `Content-Length`, even for a
streamed body, so no real client hits this. A body under 8 MiB needs no length,
because it never reaches multipart.

**Checksums default to `when_required`.** Since December 2024 the SDKs default
to sending CRC32 with `aws-chunked` framing, which many S3-compatible stores
reject. The new optional `S3_CHECKSUM_MODE=when_supported` opts back in for
real AWS.

**Object keys keep their current shape.** `rust-s3` stripped the leading slash
from the path when it built the request URL, so artifacts already in a bucket
are stored under `team/hash`. `Storage` trims it the same way. Without that,
every artifact already cached would become a permanent miss.

**Request bodies cross to the SDK through a bounded channel.** actix's payload
stream is not `Send`, while the transfer manager needs `Send + Sync + 'static`.
`send_reader` in `src/routes/artifacts.rs` bridges them with a four-chunk
channel, which also bounds the memory that bridge can hold.

**Credentials now use the full default chain** when `S3_ACCESS_KEY` and
`S3_SECRET_KEY` are absent, so instance metadata, IRSA, and profiles all work.
The chain builds on first use, so the server still starts when instance
metadata is briefly unreachable.

**The SDK retries transient S3 failures up to three times** with backoff. The
README now documents this, along with a bucket lifecycle rule to abort
incomplete multipart uploads, since a client that disconnects mid-upload leaves
parts behind that still cost storage.

## Verification

- `cargo test` — 49 pass: 30 unit, 19 end-to-end
- `cargo fmt --all -- --check`
- `RUSTFLAGS=-Dwarnings cargo clippy`
- `cargo build --release --locked`
- `docker build --target builder` — the musl cross-build for both `aarch64` and
  `x86_64`. This needed `cmake` in the build image: the transfer manager depends
  on `aws-sdk-s3` with default features, so `aws-lc-sys` joins the tree and
  compiles C. No `nasm` is needed.

Boundary coverage uses the sizes from the issue report:

| Size | Path | Stored `x-artifact-tag` |
| ---: | --- | --- |
| 12 | single `PUT` | present |
| 8,388,607 | single `PUT` | present |
| 8,388,608 | multipart | present |
| 8,715,039 | multipart | present |

All 17 pre-existing end-to-end tests pass without modification, including the
one that compares the uploaded request body byte for byte.

## Cost

| | `main` | this branch |
| --- | ---: | ---: |
| release binary | 4,891,536 bytes | 9,531,872 bytes |

The binary nearly doubles. `rust-s3` leaves, and with it the `http` and vendored
`openssl` dependencies, but the SDK tree is larger than what it replaces.

## Still to do before release

- Test against a live bucket. Everything here is exercised against wiremock. R2
  and RustFS are the ones worth checking, because the checksum default exists
  for exactly the framing those stores reject.
- `aws-sdk-s3-transfer-manager` 0.2.0 is a developer preview upstream, and its
  README says it is not recommended for production. It is confined to
  `Uploader::put`, so the fallback is a hand-written
  `create_multipart_upload`/`upload_part`/`complete_multipart_upload` sequence
  in that one function, with no route or test changes.
