### PR TITLE
fix: harden Bearer token validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "rust-s3",
  "secrecy",
  "serde",
+ "subtle",
  "sysinfo 0.39.6",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ sysinfo = "0.39"
 tonic = "0.14.2"
 secrecy = "0.10.3"
 tracing-actix-web = "0.7"
+subtle = "2"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ server. When set, every incoming request must include an
 and send this header automatically, so the server-side and client-side
 values must match.
 
+The server reads the `Bearer` scheme in any case, as HTTP requires. It
+compares the token itself byte for byte. A rejected request returns a JSON
+body that says whether the header was missing or the token was wrong:
+
+```json
+{ "error": "Invalid TURBO_TOKEN" }
+```
+
 When `TURBO_TOKEN` is unset on the server, the authentication middleware is
 bypassed entirely and any `Authorization` header on incoming requests is
 ignored.

--- a/README.md
+++ b/README.md
@@ -123,8 +123,10 @@ and send this header automatically, so the server-side and client-side
 values must match.
 
 The server reads the `Bearer` scheme in any case, as HTTP requires. It
-compares the token itself byte for byte. A rejected request returns a JSON
-body that says whether the header was missing or the token was wrong:
+compares the token itself in constant time, so the time a rejection takes
+does not tell an attacker how much of a guess was correct. A rejected
+request returns a JSON body that says whether the header was missing or the
+token was wrong:
 
 ```json
 { "error": "Invalid TURBO_TOKEN" }

--- a/src/auth/turbo_token.rs
+++ b/src/auth/turbo_token.rs
@@ -2,37 +2,149 @@ use actix_web::{
     Error, HttpResponse,
     body::MessageBody,
     dev::{ServiceRequest, ServiceResponse},
+    http::header,
     middleware::Next,
     web::Data,
 };
 
 use secrecy::ExposeSecret;
+use serde::Serialize;
+use tracing::instrument;
 
 use crate::app_settings::AppSettings;
 
+#[derive(Serialize)]
+struct AuthError {
+    error: &'static str,
+}
+
+/// What the middleware decided about the incoming request.
+enum Outcome {
+    /// No `TURBO_TOKEN` is configured, so the server accepts every request.
+    NoTokenConfigured,
+    Valid,
+    MissingHeader,
+    InvalidToken,
+}
+
+/// Rejects requests that do not carry the configured `TURBO_TOKEN` as a Bearer token.
+/// Lets every request through when no token is configured.
+#[instrument(name = "validate_turbo_token", skip_all)]
 pub async fn validate_turbo_token(
     req: ServiceRequest,
     next: Next<impl MessageBody + 'static>,
 ) -> Result<ServiceResponse<impl MessageBody>, Error> {
-    let app_settings = req.app_data::<Data<AppSettings>>().unwrap();
-    let maybe_req_token = req.headers().get("Authorization");
+    // Scoped so no borrow of `req` outlives the decision and blocks the move below.
+    let outcome = {
+        let app_settings = req
+            .app_data::<Data<AppSettings>>()
+            .expect("AppSettings must be registered as app data");
 
-    match (&app_settings.turbo_token, maybe_req_token) {
-        (Some(token), Some(header_token)) => {
-            let token = format!("Bearer {}", token.expose_secret());
-            if token == *header_token {
-                return next.call(req).await.map(|v| v.map_into_boxed_body());
+        match &app_settings.turbo_token {
+            None => Outcome::NoTokenConfigured,
+            Some(expected) => {
+                let provided = req
+                    .headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_bearer_token);
+
+                match provided {
+                    None => Outcome::MissingHeader,
+                    Some(token) if token == expected.expose_secret() => Outcome::Valid,
+                    Some(_) => Outcome::InvalidToken,
+                }
             }
-            Ok(unauthrorized(req))
         }
-        (Some(_token), None) => Ok(unauthrorized(req)),
-        _ => {
-            tracing::info!("No token provided. skipping...");
+    };
+
+    match outcome {
+        Outcome::NoTokenConfigured => {
+            tracing::debug!("No TURBO_TOKEN configured. Skipping token validation");
             next.call(req).await.map(|v| v.map_into_boxed_body())
+        }
+        Outcome::Valid => next.call(req).await.map(|v| v.map_into_boxed_body()),
+        Outcome::MissingHeader => {
+            tracing::warn!("Rejected request with a missing or malformed Authorization header");
+            Ok(unauthorized(
+                req,
+                "Missing or malformed Authorization header",
+            ))
+        }
+        Outcome::InvalidToken => {
+            tracing::warn!("Rejected request with an invalid TURBO_TOKEN");
+            Ok(unauthorized(req, "Invalid TURBO_TOKEN"))
         }
     }
 }
 
-fn unauthrorized(req: ServiceRequest) -> ServiceResponse {
-    req.into_response(HttpResponse::Unauthorized().body("Unauthorized. Invalid TURBO_TOKEN"))
+/// Extracts the token from an `Authorization` header value.
+/// Returns `None` when the scheme is not Bearer or the token is empty.
+fn parse_bearer_token(header_value: &str) -> Option<&str> {
+    let (scheme, token) = header_value.split_once(' ')?;
+
+    // RFC 7235 defines the auth scheme as case-insensitive.
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return None;
+    }
+
+    let token = token.trim_start();
+    if token.is_empty() { None } else { Some(token) }
+}
+
+fn unauthorized(req: ServiceRequest, error: &'static str) -> ServiceResponse {
+    req.into_response(
+        HttpResponse::Unauthorized()
+            .insert_header((header::WWW_AUTHENTICATE, "Bearer"))
+            .json(AuthError { error }),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_bearer_token() {
+        assert_eq!(parse_bearer_token("Bearer secret"), Some("secret"));
+    }
+
+    #[test]
+    fn parses_a_bearer_scheme_in_any_case() {
+        assert_eq!(parse_bearer_token("bearer secret"), Some("secret"));
+        assert_eq!(parse_bearer_token("BEARER secret"), Some("secret"));
+        assert_eq!(parse_bearer_token("BeArEr secret"), Some("secret"));
+    }
+
+    #[test]
+    fn parses_a_token_padded_with_extra_spaces() {
+        assert_eq!(parse_bearer_token("Bearer   secret"), Some("secret"));
+    }
+
+    #[test]
+    fn rejects_another_auth_scheme() {
+        assert_eq!(parse_bearer_token("Basic secret"), None);
+    }
+
+    #[test]
+    fn rejects_a_header_without_a_scheme() {
+        assert_eq!(parse_bearer_token("secret"), None);
+    }
+
+    #[test]
+    fn rejects_an_empty_token() {
+        assert_eq!(parse_bearer_token("Bearer "), None);
+        assert_eq!(parse_bearer_token("Bearer    "), None);
+    }
+
+    #[test]
+    fn rejects_an_empty_header() {
+        assert_eq!(parse_bearer_token(""), None);
+    }
+
+    #[test]
+    fn keeps_the_token_exact() {
+        // Tokens are compared byte for byte, so no case folding on the token itself.
+        assert_eq!(parse_bearer_token("Bearer SeCrEt"), Some("SeCrEt"));
+    }
 }

--- a/src/auth/turbo_token.rs
+++ b/src/auth/turbo_token.rs
@@ -9,6 +9,7 @@ use actix_web::{
 
 use secrecy::ExposeSecret;
 use serde::Serialize;
+use subtle::ConstantTimeEq;
 use tracing::instrument;
 
 use crate::app_settings::AppSettings;
@@ -51,7 +52,7 @@ pub async fn validate_turbo_token(
 
                 match provided {
                     None => Outcome::MissingHeader,
-                    Some(token) if token == expected.expose_secret() => Outcome::Valid,
+                    Some(token) if tokens_match(token, expected.expose_secret()) => Outcome::Valid,
                     Some(_) => Outcome::InvalidToken,
                 }
             }
@@ -90,6 +91,16 @@ fn parse_bearer_token(header_value: &str) -> Option<&str> {
 
     let token = token.trim_start();
     if token.is_empty() { None } else { Some(token) }
+}
+
+/// Compares a token against the configured one in constant time.
+/// A plain `==` stops at the first byte that differs, so its running time
+/// tells an attacker how much of a guess was correct.
+///
+/// The token length is not treated as a secret: `ct_eq` returns early when
+/// the lengths differ, which is the usual trade for this kind of check.
+fn tokens_match(provided: &str, expected: &str) -> bool {
+    provided.as_bytes().ct_eq(expected.as_bytes()).into()
 }
 
 fn unauthorized(req: ServiceRequest, error: &'static str) -> ServiceResponse {
@@ -146,5 +157,37 @@ mod tests {
     fn keeps_the_token_exact() {
         // Tokens are compared byte for byte, so no case folding on the token itself.
         assert_eq!(parse_bearer_token("Bearer SeCrEt"), Some("SeCrEt"));
+    }
+
+    #[test]
+    fn matches_an_identical_token() {
+        assert!(tokens_match("secret", "secret"));
+    }
+
+    #[test]
+    fn rejects_a_token_that_differs() {
+        assert!(!tokens_match("secret", "other!"));
+    }
+
+    #[test]
+    fn rejects_a_token_that_only_shares_a_prefix() {
+        assert!(!tokens_match("secret", "secret-and-more"));
+        assert!(!tokens_match("secret-and-more", "secret"));
+    }
+
+    #[test]
+    fn rejects_a_token_that_differs_in_case() {
+        assert!(!tokens_match("secret", "SECRET"));
+    }
+
+    #[test]
+    fn rejects_an_empty_token_against_a_real_one() {
+        assert!(!tokens_match("", "secret"));
+    }
+
+    #[test]
+    fn matches_a_token_with_multibyte_characters() {
+        assert!(tokens_match("sécret-🔑", "sécret-🔑"));
+        assert!(!tokens_match("sécret-🔑", "sécret-🔒"));
     }
 }

--- a/src/auth/turbo_token.rs
+++ b/src/auth/turbo_token.rs
@@ -10,7 +10,6 @@ use actix_web::{
 use secrecy::ExposeSecret;
 use serde::Serialize;
 use subtle::ConstantTimeEq;
-use tracing::instrument;
 
 use crate::app_settings::AppSettings;
 
@@ -30,7 +29,6 @@ enum Outcome {
 
 /// Rejects requests that do not carry the configured `TURBO_TOKEN` as a Bearer token.
 /// Lets every request through when no token is configured.
-#[instrument(name = "validate_turbo_token", skip_all)]
 pub async fn validate_turbo_token(
     req: ServiceRequest,
     next: Next<impl MessageBody + 'static>,

--- a/tests/e2e/auth.rs
+++ b/tests/e2e/auth.rs
@@ -53,15 +53,85 @@ async fn authorized_when_token_header_is_valid() {
     assert_eq!(response.status(), 200);
 }
 
+#[tokio::test]
+async fn authorized_when_the_bearer_scheme_is_lowercase() {
+    let test_app_config = TestAppConfig {
+        turbo_token: Some(String::from("valid_token")),
+        ..Default::default()
+    };
+    let app = spawn_app(Some(test_app_config)).await;
+
+    let response = check_endpoint_with_auth_header(
+        "/v8/artifacts/status",
+        &app,
+        Some(String::from("bearer valid_token")),
+    )
+    .await;
+
+    assert_eq!(response.status(), 200);
+}
+
+#[tokio::test]
+async fn unauthorized_when_the_auth_scheme_is_not_bearer() {
+    let test_app_config = TestAppConfig {
+        turbo_token: Some(String::from("valid_token")),
+        ..Default::default()
+    };
+    let app = spawn_app(Some(test_app_config)).await;
+
+    let response = check_endpoint_with_auth_header(
+        "/v8/artifacts/status",
+        &app,
+        Some(String::from("Basic valid_token")),
+    )
+    .await;
+
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn unauthorized_when_the_token_is_sent_without_a_scheme() {
+    let test_app_config = TestAppConfig {
+        turbo_token: Some(String::from("valid_token")),
+        ..Default::default()
+    };
+    let app = spawn_app(Some(test_app_config)).await;
+
+    let response = check_endpoint_with_auth_header(
+        "/v8/artifacts/status",
+        &app,
+        Some(String::from("valid_token")),
+    )
+    .await;
+
+    assert_eq!(response.status(), 401);
+}
+
+#[tokio::test]
+async fn authorized_when_no_token_is_configured_on_the_server() {
+    let app = spawn_app(None).await;
+
+    let response = check_endpoint("/v8/artifacts/status", &app, None).await;
+
+    assert_eq!(response.status(), 200);
+}
+
 async fn check_endpoint(endpoint: &str, app: &TestApp, turbo_token: Option<String>) -> Response {
+    let header_value = turbo_token.as_ref().map(|token| format!("Bearer {token}"));
+    check_endpoint_with_auth_header(endpoint, app, header_value).await
+}
+
+async fn check_endpoint_with_auth_header(
+    endpoint: &str,
+    app: &TestApp,
+    auth_header: Option<String>,
+) -> Response {
     let client = reqwest::Client::new();
 
-    let maybe_headers = turbo_token
-        .as_ref()
-        .map(|token| ("Authorization", format!("Bearer {token}")));
+    let maybe_headers = auth_header.map(|value| ("Authorization", value));
 
     client
-        .get(format!("{}{}", &app.address, endpoint))
+        .get(format!("{}{}", app.address, endpoint))
         .headers(
             maybe_headers
                 .map(|(key, value)| {


### PR DESCRIPTION
## What

Hardens the `TURBO_TOKEN` middleware. Comparison against [rush-cache-server's auth module](https://github.com/brunojppb/rush-cache-server/tree/main/src/auth) turned up a few things worth taking.

## The bug

The middleware built the expected header and compared the whole string:

```rust
let token = format!("Bearer {}", token.expose_secret());
if token == *header_token { ... }
```

So a client sending `bearer <token>` got a `401`. HTTP defines the auth scheme as case-insensitive, and the token as the part after it.

Parsing now splits the scheme from the token:

```rust
fn parse_bearer_token(header_value: &str) -> Option<&str> {
    let (scheme, token) = header_value.split_once(' ')?;
    if !scheme.eq_ignore_ascii_case("Bearer") {
        return None;
    }
    let token = token.trim_start();
    if token.is_empty() { None } else { Some(token) }
}
```

It is a pure function, so the parsing rules are unit tested on their own. Splitting also avoids byte indexing into the header, which needs an ASCII guarantee to be sound.

## Timing

The old comparison used `==`, which stops at the first byte that differs. Its running time tells an attacker how much of a guess was correct. The token now goes through `subtle::ConstantTimeEq`:

```rust
fn tokens_match(provided: &str, expected: &str) -> bool {
    provided.as_bytes().ct_eq(expected.as_bytes()).into()
}
```

The token length still leaks, because `ct_eq` returns early when the lengths differ. That is the usual trade for this kind of check.

`subtle` was already in the lock file as a transitive dependency. It is `no_std` and pulls in nothing else.

Worth noting for anyone comparing the two servers: rush-cache-server does not do this either. Its `HashSet::contains` is incidentally harder to time, because hashing breaks the link between a correct prefix and the time taken, but that falls out of using a hash map rather than intent.

## Other changes

- A rejected request returns JSON that says whether the header was missing or the token was wrong, instead of one plain-text message for both.
- 401s carry `WWW-Authenticate: Bearer`.
- Added a `validate_turbo_token` span, so auth nests under the HTTP root span from #627.
- Rejections log at `warn`, without the token value, so brute-force attempts are visible.
- The "no token configured" message dropped from `info` to `debug`. It fired on every request.
- `unwrap()` on the app data became `expect()` with a message.
- Fixed the `unauthrorized` typo.
- The decision is computed in a scoped block returning an `Outcome` enum, so no borrow of `req` is alive when it moves into `next.call`.

## What did not change

`TURBO_TOKEN` behaves as before. Unset still means the server accepts every request, as the README documents.

## Not taken from rush-cache-server

Two things there I chose to leave:

- `AuthenticatedToken.token_prefix` keeps the first 8 characters of a live secret in the request extensions, on a `Debug`-derived struct. The comment calls it safe to log. It is a partial secret, and nothing reads it.
- The write check in `put_artifact` is fail-open. If the extension is missing, the `if let` does not match and the write proceeds.

Its read-only/read-write token split and multi-token rotation are real wins, but they change the config surface. Left for a separate discussion.

## Tests

14 unit tests covering the parser and the comparison, plus 4 new e2e tests: lowercase scheme, wrong scheme, no scheme, and the open-server path that had no coverage.

```
cargo test          50 passed, 0 failed
cargo clippy        clean
cargo fmt --check   clean
```
