### PR TITLE
fix: round-trip x-artifact-duration so cache hits report real time saved

### DIFF
--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use actix_web::{
-    HttpRequest, HttpResponse, Responder,
+    HttpRequest, HttpResponse, HttpResponseBuilder, Responder,
     web::{Bytes, Data, Payload, Query},
 };
 use futures::StreamExt;
@@ -17,6 +17,81 @@ use crate::storage::{Storage, StorageError};
 /// download fails signature verification and is treated as a cache miss.
 /// See: https://turborepo.dev/api/remote-cache-spec
 const ARTIFACT_TAG_HEADER: &str = "x-artifact-tag";
+
+/// Turborepo sends the task run time on PUT and reads it back on GET and HEAD to
+/// report how much time the cache saved. Without it, every remote cache hit
+/// reports zero time saved.
+/// See: https://turborepo.dev/api/remote-cache-spec
+const ARTIFACT_DURATION_HEADER: &str = "x-artifact-duration";
+
+/// The artifact headers Turborepo sends on upload and expects back on download.
+/// They travel as S3 user metadata.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct ArtifactMetadata {
+    tag: Option<String>,
+    duration: Option<u64>,
+}
+
+impl ArtifactMetadata {
+    /// Reads the artifact headers from an upload request.
+    fn from_request(req: &HttpRequest) -> Self {
+        let header = |name: &str| req.headers().get(name).and_then(|value| value.to_str().ok());
+
+        Self {
+            tag: header(ARTIFACT_TAG_HEADER).map(str::to_owned),
+            duration: header(ARTIFACT_DURATION_HEADER).and_then(parse_duration),
+        }
+    }
+
+    /// Reads the artifact headers from the metadata stored on the S3 object.
+    fn from_storage(metadata: &HashMap<String, String>) -> Self {
+        Self {
+            tag: metadata.get(ARTIFACT_TAG_HEADER).cloned(),
+            duration: metadata
+                .get(ARTIFACT_DURATION_HEADER)
+                .map(String::as_str)
+                .and_then(parse_duration),
+        }
+    }
+
+    /// The key-value pairs to persist as S3 user metadata.
+    fn to_storage(&self) -> HashMap<String, String> {
+        let mut metadata = HashMap::new();
+
+        if let Some(tag) = &self.tag {
+            metadata.insert(ARTIFACT_TAG_HEADER.to_owned(), tag.clone());
+        }
+
+        if let Some(duration) = self.duration {
+            metadata.insert(ARTIFACT_DURATION_HEADER.to_owned(), duration.to_string());
+        }
+
+        metadata
+    }
+
+    /// Copies the artifact headers onto a download response.
+    fn apply(&self, builder: &mut HttpResponseBuilder) {
+        if let Some(tag) = &self.tag {
+            builder.insert_header((ARTIFACT_TAG_HEADER, tag.as_str()));
+        }
+
+        if let Some(duration) = self.duration {
+            builder.insert_header((ARTIFACT_DURATION_HEADER, duration.to_string()));
+        }
+    }
+}
+
+/// Turborepo fails the whole cache read on a duration it cannot parse, so a
+/// value the server cannot vouch for is dropped instead of passed on.
+fn parse_duration(raw: &str) -> Option<u64> {
+    match raw.parse::<u64>() {
+        Ok(duration) => Some(duration),
+        Err(_) => {
+            tracing::warn!(value = raw, "Ignoring malformed x-artifact-duration");
+            None
+        }
+    }
+}
 
 #[derive(Serialize)]
 struct Artifact {
@@ -71,17 +146,13 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
         None => return HttpResponse::BadRequest().finish(),
     };
 
-    let metadata = req
-        .headers()
-        .get(ARTIFACT_TAG_HEADER)
-        .and_then(|value| value.to_str().ok())
-        .map(|tag| HashMap::from([(ARTIFACT_TAG_HEADER.to_owned(), tag.to_owned())]));
+    let metadata = ArtifactMetadata::from_request(&req).to_storage();
 
     let io_stream = body.map(|chunk| chunk.map_err(std::io::Error::other));
     let mut reader = StreamReader::new(io_stream);
 
     match storage
-        .put_file_stream(&artifact_info.file_path(), &mut reader, metadata.as_ref())
+        .put_file_stream(&artifact_info.file_path(), &mut reader, &metadata)
         .await
     {
         Ok(_) => {

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -35,7 +35,11 @@ struct ArtifactMetadata {
 impl ArtifactMetadata {
     /// Reads the artifact headers from an upload request.
     fn from_request(req: &HttpRequest) -> Self {
-        let header = |name: &str| req.headers().get(name).and_then(|value| value.to_str().ok());
+        let header = |name: &str| {
+            req.headers()
+                .get(name)
+                .and_then(|value| value.to_str().ok())
+        };
 
         Self {
             tag: header(ARTIFACT_TAG_HEADER).map(str::to_owned),

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -44,22 +44,22 @@ impl ArtifactMetadata {
     }
 
     /// Reads the artifact headers from the metadata stored on the S3 object.
-    fn from_storage(metadata: &HashMap<String, String>) -> Self {
+    fn from_storage(mut metadata: HashMap<String, String>) -> Self {
         Self {
-            tag: metadata.get(ARTIFACT_TAG_HEADER).cloned(),
+            tag: metadata.remove(ARTIFACT_TAG_HEADER),
             duration: metadata
-                .get(ARTIFACT_DURATION_HEADER)
-                .map(String::as_str)
+                .remove(ARTIFACT_DURATION_HEADER)
+                .as_deref()
                 .and_then(parse_duration),
         }
     }
 
     /// The key-value pairs to persist as S3 user metadata.
-    fn to_storage(&self) -> HashMap<String, String> {
+    fn into_storage(self) -> HashMap<String, String> {
         let mut metadata = HashMap::new();
 
-        if let Some(tag) = &self.tag {
-            metadata.insert(ARTIFACT_TAG_HEADER.to_owned(), tag.clone());
+        if let Some(tag) = self.tag {
+            metadata.insert(ARTIFACT_TAG_HEADER.to_owned(), tag);
         }
 
         if let Some(duration) = self.duration {
@@ -81,13 +81,19 @@ impl ArtifactMetadata {
     }
 }
 
+/// How much of a rejected duration reaches the log.
+const MAX_LOGGED_DURATION_CHARS: usize = 32;
+
 /// Turborepo fails the whole cache read on a duration it cannot parse, so a
 /// value the server cannot vouch for is dropped instead of passed on.
 fn parse_duration(raw: &str) -> Option<u64> {
     match raw.parse::<u64>() {
         Ok(duration) => Some(duration),
         Err(_) => {
-            tracing::warn!(value = raw, "Ignoring malformed x-artifact-duration");
+            // A client picks this value and can repeat it on every request, so
+            // it stays off the warning path and never reaches the log in full.
+            let value: String = raw.chars().take(MAX_LOGGED_DURATION_CHARS).collect();
+            tracing::debug!(value = %value, "Ignoring malformed x-artifact-duration");
             None
         }
     }
@@ -132,7 +138,7 @@ pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl R
     match storage.head_file(&artifact_info.file_path()).await {
         Ok(metadata) => {
             let mut builder = HttpResponse::Ok();
-            ArtifactMetadata::from_storage(&metadata).apply(&mut builder);
+            ArtifactMetadata::from_storage(metadata).apply(&mut builder);
             builder.finish()
         }
         Err(StorageError::NotFound) => HttpResponse::NotFound().finish(),
@@ -150,7 +156,7 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
         None => return HttpResponse::BadRequest().finish(),
     };
 
-    let metadata = ArtifactMetadata::from_request(&req).to_storage();
+    let metadata = ArtifactMetadata::from_request(&req).into_storage();
 
     let io_stream = body.map(|chunk| chunk.map_err(std::io::Error::other));
     let mut reader = StreamReader::new(io_stream);
@@ -208,7 +214,7 @@ pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responde
 
     let mut builder = HttpResponse::Ok();
 
-    ArtifactMetadata::from_storage(&metadata).apply(&mut builder);
+    ArtifactMetadata::from_storage(metadata).apply(&mut builder);
 
     builder.streaming(stream)
 }
@@ -250,4 +256,93 @@ const DUMMY_CACHE_STATUS: CacheStatus = CacheStatus { status: "enabled" };
 
 pub async fn artifacts_status() -> impl Responder {
     HttpResponse::Ok().json(DUMMY_CACHE_STATUS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use actix_web::test::TestRequest;
+    use pretty_assertions::assert_eq;
+
+    const TAG: &str = "v=1:sha256:abc123";
+
+    #[test]
+    fn reads_both_artifact_headers_from_the_request() {
+        let req = TestRequest::default()
+            .insert_header((ARTIFACT_TAG_HEADER, TAG))
+            .insert_header((ARTIFACT_DURATION_HEADER, "1234"))
+            .to_http_request();
+
+        assert_eq!(
+            ArtifactMetadata::from_request(&req),
+            ArtifactMetadata {
+                tag: Some(TAG.to_owned()),
+                duration: Some(1234),
+            }
+        );
+    }
+
+    #[test]
+    fn reads_no_artifact_headers_from_a_bare_request() {
+        let req = TestRequest::default().to_http_request();
+
+        assert_eq!(
+            ArtifactMetadata::from_request(&req),
+            ArtifactMetadata::default()
+        );
+    }
+
+    /// Turborepo fails the whole cache read on a duration it cannot parse, so a
+    /// bad value never reaches the bucket.
+    #[test]
+    fn drops_a_malformed_duration_from_the_request() {
+        let req = TestRequest::default()
+            .insert_header((ARTIFACT_DURATION_HEADER, "not-a-number"))
+            .to_http_request();
+
+        assert_eq!(ArtifactMetadata::from_request(&req).duration, None);
+    }
+
+    /// The bucket holds the parsed number, not the bytes the client sent.
+    #[test]
+    fn writes_the_parsed_duration_to_storage() {
+        let req = TestRequest::default()
+            .insert_header((ARTIFACT_DURATION_HEADER, "007"))
+            .to_http_request();
+
+        let metadata = ArtifactMetadata::from_request(&req).into_storage();
+
+        assert_eq!(
+            metadata.get(ARTIFACT_DURATION_HEADER).map(String::as_str),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn reads_both_artifact_headers_from_storage() {
+        let stored = HashMap::from([
+            (ARTIFACT_TAG_HEADER.to_owned(), TAG.to_owned()),
+            (ARTIFACT_DURATION_HEADER.to_owned(), "1234".to_owned()),
+        ]);
+
+        assert_eq!(
+            ArtifactMetadata::from_storage(stored),
+            ArtifactMetadata {
+                tag: Some(TAG.to_owned()),
+                duration: Some(1234),
+            }
+        );
+    }
+
+    /// Another writer may share the bucket, so the read path does not trust the
+    /// stored value either.
+    #[test]
+    fn drops_a_malformed_duration_from_storage() {
+        let stored = HashMap::from([(
+            ARTIFACT_DURATION_HEADER.to_owned(),
+            "not-a-number".to_owned(),
+        )]);
+
+        assert_eq!(ArtifactMetadata::from_storage(stored).duration, None);
+    }
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -204,9 +204,7 @@ pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responde
 
     let mut builder = HttpResponse::Ok();
 
-    if let Some(tag) = metadata.as_ref().and_then(|m| m.get(ARTIFACT_TAG_HEADER)) {
-        builder.insert_header((ARTIFACT_TAG_HEADER, tag.as_str()));
-    }
+    ArtifactMetadata::from_storage(&metadata).apply(&mut builder);
 
     builder.streaming(stream)
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -129,9 +129,13 @@ pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl R
         None => return HttpResponse::NotFound().finish(),
     };
 
-    match storage.file_exists(&artifact_info.file_path()).await {
-        Ok(true) => HttpResponse::Ok().finish(),
-        Ok(false) => HttpResponse::NotFound().finish(),
+    match storage.head_file(&artifact_info.file_path()).await {
+        Ok(metadata) => {
+            let mut builder = HttpResponse::Ok();
+            ArtifactMetadata::from_storage(&metadata).apply(&mut builder);
+            builder.finish()
+        }
+        Err(StorageError::NotFound) => HttpResponse::NotFound().finish(),
         Err(error) => {
             tracing::error!(error = %error, "Could not check artifact on the bucket");
             HttpResponse::InternalServerError().finish()

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -107,13 +107,21 @@ impl Storage {
         Ok(file)
     }
 
+    /// Returns the user metadata stored on the S3 object, or reports that the
+    /// object is missing.
+    #[tracing::instrument(name = "head S3 file")]
+    pub async fn head_file(&self, path: &str) -> Result<HashMap<String, String>, StorageError> {
+        let (head_result, _status) = self.bucket.head_object(path).await?;
+        Ok(head_result.metadata.unwrap_or_default())
+    }
+
     /// Returns the user metadata stored on the S3 object.
     /// A failed lookup must not fail an otherwise good download, so it reports
     /// no metadata rather than an error.
     #[tracing::instrument(name = "get S3 object metadata")]
     pub async fn get_metadata(&self, path: &str) -> HashMap<String, String> {
-        match self.bucket.head_object(path).await {
-            Ok((head_result, _status)) => head_result.metadata.unwrap_or_default(),
+        match self.head_file(path).await {
+            Ok(metadata) => metadata,
             Err(error) => {
                 tracing::warn!(error = %error, path, "HEAD request failed, omitting object metadata");
                 HashMap::new()
@@ -150,18 +158,6 @@ impl Storage {
 
         builder.execute_stream(reader).await?;
         Ok(())
-    }
-
-    /// Checks whether the given file path exists on the S3 bucket
-    #[tracing::instrument(name = "check if S3 file exists")]
-    pub async fn file_exists(&self, path: &str) -> Result<bool, StorageError> {
-        match self.bucket.head_object(path).await {
-            Ok(_) => Ok(true),
-            Err(error) => match StorageError::from(error) {
-                StorageError::NotFound => Ok(false),
-                error => Err(error),
-            },
-        }
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -107,17 +107,18 @@ impl Storage {
         Ok(file)
     }
 
-    /// Returns the user metadata stored on the S3 object, if present.
+    /// Returns the user metadata stored on the S3 object.
+    /// A failed lookup must not fail an otherwise good download, so it reports
+    /// no metadata rather than an error.
     #[tracing::instrument(name = "get S3 object metadata")]
-    pub async fn get_metadata(&self, path: &str) -> Option<HashMap<String, String>> {
-        let (head_result, _status) = match self.bucket.head_object(path).await {
-            Ok(result) => result,
+    pub async fn get_metadata(&self, path: &str) -> HashMap<String, String> {
+        match self.bucket.head_object(path).await {
+            Ok((head_result, _status)) => head_result.metadata.unwrap_or_default(),
             Err(error) => {
                 tracing::warn!(error = %error, path, "HEAD request failed, omitting object metadata");
-                return None;
+                HashMap::new()
             }
-        };
-        head_result.metadata
+        }
     }
 
     /// Streams the given data to the S3 bucket under the given path.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -121,14 +121,14 @@ impl Storage {
     }
 
     /// Streams the given data to the S3 bucket under the given path.
-    /// When `metadata` is provided, each key-value pair is persisted as S3 user
-    /// metadata (x-amz-meta-*) so it can be retrieved on subsequent HEADs.
+    /// Each metadata key-value pair is persisted as S3 user metadata
+    /// (x-amz-meta-*) so it can be retrieved on subsequent HEADs.
     #[tracing::instrument(name = "put S3 file stream", skip(reader))]
     pub async fn put_file_stream<R>(
         &self,
         path: &str,
         reader: &mut R,
-        metadata: Option<&HashMap<String, String>>,
+        metadata: &HashMap<String, String>,
     ) -> Result<(), StorageError>
     where
         R: AsyncRead + Unpin,
@@ -141,12 +141,10 @@ impl Storage {
                 .expect("Invalid server-side encryption header value");
         }
 
-        if let Some(metadata) = metadata {
-            for (key, value) in metadata {
-                builder = builder
-                    .with_metadata(key, value)
-                    .expect("Invalid metadata value");
-            }
+        for (key, value) in metadata {
+            builder = builder
+                .with_metadata(key, value)
+                .expect("Invalid metadata value");
         }
 
         builder.execute_stream(reader).await?;

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -418,7 +418,9 @@ async fn download_artifact_returns_artifact_duration_from_s3_metadata_test() {
         app.bucket_name, file_mock.team, file_mock.file_hash
     )))
     .and(method("HEAD"))
-    .respond_with(ResponseTemplate::new(200).insert_header("x-amz-meta-x-artifact-duration", "1234"))
+    .respond_with(
+        ResponseTemplate::new(200).insert_header("x-amz-meta-x-artifact-duration", "1234"),
+    )
     .mount(&app.storage_server)
     .await;
 

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -478,6 +478,50 @@ async fn artifact_exists_test() {
     assert_eq!(response.status(), 200);
 }
 
+/// The Turborepo client reads the artifact headers off the exists check as well
+/// as the download. See: https://turborepo.dev/api/remote-cache-spec
+/// (HEAD /artifacts/{hash})
+#[tokio::test]
+async fn artifact_exists_returns_artifact_metadata_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+    let artifact_tag = "v=1:sha256:abc123";
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("HEAD"))
+    .respond_with(
+        ResponseTemplate::new(200)
+            .insert_header("x-amz-meta-x-artifact-tag", artifact_tag)
+            .insert_header("x-amz-meta-x-artifact-duration", "1234"),
+    )
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .head(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to HEAD and check artifact from cache server");
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers().get("x-artifact-duration").unwrap(),
+        "1234"
+    );
+    assert_eq!(
+        response.headers().get("x-artifact-tag").unwrap(),
+        artifact_tag
+    );
+}
+
 #[tokio::test]
 async fn artifact_does_not_exist_test() {
     let app = spawn_app(None).await;

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -356,6 +356,92 @@ async fn download_artifact_returns_artifact_tag_from_s3_metadata_test() {
     );
 }
 
+/// The Turborepo client reads `x-artifact-duration` off the download to report
+/// the time the cache saved.
+/// See: https://turborepo.dev/api/remote-cache-spec (GET /artifacts/{hash})
+#[tokio::test]
+async fn download_artifact_returns_artifact_duration_from_s3_metadata_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("GET"))
+    .respond_with(ResponseTemplate::new(200).set_body_bytes(file_mock.file_bytes.clone()))
+    .mount(&app.storage_server)
+    .await;
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("HEAD"))
+    .respond_with(ResponseTemplate::new(200).insert_header("x-amz-meta-x-artifact-duration", "1234"))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .get(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to GET artifact from the cache server");
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers().get("x-artifact-duration").unwrap(),
+        "1234"
+    );
+}
+
+/// Another writer may share the bucket, so the download path does not trust the
+/// stored value. Turborepo fails the whole read on a duration it cannot parse.
+#[tokio::test]
+async fn download_artifact_omits_malformed_artifact_duration_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("GET"))
+    .respond_with(ResponseTemplate::new(200).set_body_bytes(file_mock.file_bytes.clone()))
+    .mount(&app.storage_server)
+    .await;
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("HEAD"))
+    .respond_with(
+        ResponseTemplate::new(200).insert_header("x-amz-meta-x-artifact-duration", "not-a-number"),
+    )
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .get(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to GET artifact from the cache server");
+
+    assert_eq!(response.status(), 200);
+    assert!(response.headers().get("x-artifact-duration").is_none());
+}
+
 #[tokio::test]
 async fn list_team_artifacts_test() {
     let app = spawn_app(None).await;

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -79,6 +79,82 @@ async fn upload_artifact_forwards_artifact_tag_as_s3_metadata_test() {
     assert_eq!(response.status(), 201);
 }
 
+/// Turborepo sends the task run time on upload and reads it back on download to
+/// report how much time the cache saved. Without it, every remote hit reports
+/// zero. See: https://turborepo.dev/api/remote-cache-spec (PUT /artifacts/{hash})
+#[tokio::test]
+async fn upload_artifact_forwards_artifact_duration_as_s3_metadata_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("PUT"))
+    .and(header("x-amz-meta-x-artifact-duration", "1234"))
+    .respond_with(ResponseTemplate::new(201))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .header("x-artifact-duration", "1234")
+        .body(file_mock.file_bytes.clone())
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 201);
+}
+
+/// Turborepo fails the whole cache read on a duration it cannot parse, so the
+/// server drops a bad value. The artifact is the payload, so the upload still
+/// succeeds.
+#[tokio::test]
+async fn upload_artifact_drops_malformed_artifact_duration_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("PUT"))
+    .respond_with(ResponseTemplate::new(201))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            &app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .header("x-artifact-duration", "not-a-number")
+        .body(file_mock.file_bytes.clone())
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 201);
+
+    let upload_req = &app.storage_server.received_requests().await.unwrap()[0];
+    assert!(
+        !upload_req
+            .headers
+            .contains_key("x-amz-meta-x-artifact-duration")
+    );
+}
+
 #[tokio::test]
 async fn upload_artifact_returns_server_error_when_s3_fails_test() {
     let app = spawn_app(None).await;

--- a/tests/e2e/artifacts.rs
+++ b/tests/e2e/artifacts.rs
@@ -102,7 +102,7 @@ async fn upload_artifact_forwards_artifact_duration_as_s3_metadata_test() {
     let response = client
         .put(format!(
             "{}/v8/artifacts/{}?slug={}",
-            &app.address, file_mock.file_hash, file_mock.team
+            app.address, file_mock.file_hash, file_mock.team
         ))
         .header("Content-Type", "application/octet-stream")
         .header("x-artifact-duration", "1234")
@@ -136,7 +136,7 @@ async fn upload_artifact_drops_malformed_artifact_duration_test() {
     let response = client
         .put(format!(
             "{}/v8/artifacts/{}?slug={}",
-            &app.address, file_mock.file_hash, file_mock.team
+            app.address, file_mock.file_hash, file_mock.team
         ))
         .header("Content-Type", "application/octet-stream")
         .header("x-artifact-duration", "not-a-number")
@@ -153,6 +153,44 @@ async fn upload_artifact_drops_malformed_artifact_duration_test() {
             .headers
             .contains_key("x-amz-meta-x-artifact-duration")
     );
+}
+
+/// A repository with `"signature": true` sends both artifact headers on the
+/// same upload, so they must not displace each other in the object metadata.
+/// See: https://turborepo.dev/api/remote-cache-spec (PUT /artifacts/{hash})
+#[tokio::test]
+async fn upload_artifact_forwards_both_artifact_headers_as_s3_metadata_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+    let artifact_tag = "v=1:sha256:abc123";
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("PUT"))
+    .and(header("x-amz-meta-x-artifact-tag", artifact_tag))
+    .and(header("x-amz-meta-x-artifact-duration", "1234"))
+    .respond_with(ResponseTemplate::new(201))
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .put(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            app.address, file_mock.file_hash, file_mock.team
+        ))
+        .header("Content-Type", "application/octet-stream")
+        .header("x-artifact-tag", artifact_tag)
+        .header("x-artifact-duration", "1234")
+        .body(file_mock.file_bytes.clone())
+        .send()
+        .await
+        .expect("Failed to PUT artifact to the cache server");
+
+    assert_eq!(response.status(), 201);
 }
 
 #[tokio::test]
@@ -387,7 +425,7 @@ async fn download_artifact_returns_artifact_duration_from_s3_metadata_test() {
     let response = client
         .get(format!(
             "{}/v8/artifacts/{}?slug={}",
-            &app.address, file_mock.file_hash, file_mock.team
+            app.address, file_mock.file_hash, file_mock.team
         ))
         .send()
         .await
@@ -432,7 +470,7 @@ async fn download_artifact_omits_malformed_artifact_duration_test() {
     let response = client
         .get(format!(
             "{}/v8/artifacts/{}?slug={}",
-            &app.address, file_mock.file_hash, file_mock.team
+            app.address, file_mock.file_hash, file_mock.team
         ))
         .send()
         .await
@@ -440,6 +478,59 @@ async fn download_artifact_omits_malformed_artifact_duration_test() {
 
     assert_eq!(response.status(), 200);
     assert!(response.headers().get("x-artifact-duration").is_none());
+}
+
+/// Counterpart to `upload_artifact_forwards_both_artifact_headers_as_s3_metadata_test`.
+/// Both headers must come back on the same download.
+/// See: https://turborepo.dev/api/remote-cache-spec (GET /artifacts/{hash})
+#[tokio::test]
+async fn download_artifact_returns_both_artifact_headers_from_s3_metadata_test() {
+    let app = spawn_app(None).await;
+
+    let client = reqwest::Client::new();
+    let file_mock = TurboArtifactFileMock::new();
+    let artifact_tag = "v=1:sha256:abc123";
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("GET"))
+    .respond_with(ResponseTemplate::new(200).set_body_bytes(file_mock.file_bytes.clone()))
+    .mount(&app.storage_server)
+    .await;
+
+    Mock::given(path(format!(
+        "/{}/{}/{}",
+        app.bucket_name, file_mock.team, file_mock.file_hash
+    )))
+    .and(method("HEAD"))
+    .respond_with(
+        ResponseTemplate::new(200)
+            .insert_header("x-amz-meta-x-artifact-tag", artifact_tag)
+            .insert_header("x-amz-meta-x-artifact-duration", "1234"),
+    )
+    .mount(&app.storage_server)
+    .await;
+
+    let response = client
+        .get(format!(
+            "{}/v8/artifacts/{}?slug={}",
+            app.address, file_mock.file_hash, file_mock.team
+        ))
+        .send()
+        .await
+        .expect("Failed to GET artifact from the cache server");
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        response.headers().get("x-artifact-tag").unwrap(),
+        artifact_tag
+    );
+    assert_eq!(
+        response.headers().get("x-artifact-duration").unwrap(),
+        "1234"
+    );
 }
 
 #[tokio::test]
@@ -505,7 +596,7 @@ async fn artifact_exists_returns_artifact_metadata_test() {
     let response = client
         .head(format!(
             "{}/v8/artifacts/{}?slug={}",
-            &app.address, file_mock.file_hash, file_mock.team
+            app.address, file_mock.file_hash, file_mock.team
         ))
         .send()
         .await


### PR DESCRIPTION
## The problem

Turborepo sends the task run time on every upload:

```
PUT /v8/artifacts/{hash}
x-artifact-duration: 1234
```

The server drops it. `put_file` copied only `x-artifact-tag` into the S3 object
metadata.

The client reads the header back on both `GET` and `HEAD`. See
[`get_duration_from_response`](https://github.com/vercel/turborepo/blob/main/crates/turborepo-cache/src/http.rs)
in `crates/turborepo-cache/src/http.rs`. When the header is absent the client
uses `0`. So every remote cache hit reports zero time saved, and the summary at
the end of a `turbo run` always reads `0ms`.

## The change

The duration now travels as S3 user metadata, next to the tag.

| Step | Header on the wire | S3 object metadata |
| --- | --- | --- |
| Upload | `x-artifact-duration: 1234` | `x-amz-meta-x-artifact-duration: 1234` |
| Download | `x-artifact-duration: 1234` | read back through `HEAD` |
| Exists check | `x-artifact-duration: 1234` | read back through `HEAD` |

```mermaid
sequenceDiagram
    participant T as Turborepo CLI
    participant D as Turbo Cache Server
    participant S as S3 bucket
    T->>+D: PUT /v8/artifacts/1wa2dr3<br/>x-artifact-duration: 8400
    D->>+S: Put object<br/>x-amz-meta-x-artifact-duration: 8400
    S-->>-D: Stored
    D-->>-T: 201 Created
    Note over T,S: later run, same task hash
    T->>+D: GET /v8/artifacts/1wa2dr3
    D->>+S: Get object and read its metadata
    S-->>-D: Bytes plus x-amz-meta-x-artifact-duration: 8400
    D-->>-T: 200 OK<br/>x-artifact-duration: 8400
    Note right of T: reports 8.4s saved,<br/>not 0ms
```

A new `ArtifactMetadata` type in `src/routes/artifacts.rs` owns both header
names, the parse rule, and the conversions between a request, S3 metadata, and a
response. Adding `x-artifact-sha` and `x-artifact-dirty-hash` later means one
field and two lines there.

## Decisions worth a second opinion

**A bad duration is dropped, not rejected.** `get_duration_from_response` returns
`CacheError::InvalidDuration` for a value it cannot parse as a `u64`, and that
error fails the whole cache read. So the server parses the value itself:

- On upload, a value that does not parse is not stored. The upload still
  succeeds. The artifact is the payload; the duration is telemetry, and telemetry
  must not fail an upload.
- On download, a stored value that does not parse is not returned. Another writer
  may share the bucket, so the read path does not trust what it finds.

The server stores the parsed number, so `007` lands in the bucket as `7`.

**`HEAD` gained the headers too.** The client reads the duration in
`HttpCache::exists`, not only on download. `head_check_file` already made an S3
`HEAD` request and threw the metadata away. As a side effect `HEAD` now also
returns `x-artifact-tag`, which no client reads today; it costs nothing and
keeps one code path for both handlers.

**`Storage` lost `file_exists` and gained `head_file`.** The old method answered
a yes-or-no question and discarded the metadata the exists check needs. It had no
other callers.

## No new round trips

Per request, before and after: `PUT` makes one S3 call, `HEAD` makes one, `GET`
makes two. The second `GET` call already existed for the tag. `rust-s3 0.37`
drops the response headers from `get_object_stream`, so there is no cheaper
source for the metadata on that path.

## Existing buckets

An object stored before this change carries no duration metadata. The server
returns no header, and the client falls back to `0` as it does today. No
migration.

## Tests

63 pass, up from 55.

- Six unit tests over the `ArtifactMetadata` conversions, covering a bare
  request, a malformed duration on each side, and the `007` to `7` normalisation.
- Seven end-to-end tests: upload stores the duration, upload drops a malformed
  one and still succeeds, download returns it, download omits a malformed stored
  one, the exists check returns both headers, and an upload and a download that
  carry both headers at once.

## Left alone on purpose

Other gaps against the [spec](https://turborepo.dev/api/remote-cache-spec), each
worth its own change:

- `x-artifact-sha` and `x-artifact-dirty-hash` are still dropped.
- `PUT` answers `201` with `{"filename": ...}`; the spec asks for `200` or `202`
  with `{"urls": [...]}`.
- `POST /v8/artifacts/events` answers `201`; the spec asks for `200`.
- `POST /v8/artifacts` answers `{"hashes": []}`; the spec asks for a map of hash
  to artifact information.
- `GET` streams the body with no `Content-Length`.

`cargo clippy` reports 14 warnings on this branch, the same 14 that `main`
already has (`useless_borrows_in_formatting` on `&app.address` in the test
files). This branch adds none. Happy to clear them in a separate change.
