### PR TITLE
refactor: separate HTTP routes from business logic with a use-case layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ name = "decay"
 version = "0.0.0"
 dependencies = [
  "actix-web",
+ "bytes",
  "dotenv",
  "futures",
  "http 1.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ name = "decay"
 
 [dependencies]
 actix-web = "4"
+bytes = "1"
 dotenv = "0.15.0"
 rust-s3 = "0.37"
 serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
 tokio-util = { version = "0.7", features = ["io"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-appender = "0.2"

--- a/src/domain/artifact.rs
+++ b/src/domain/artifact.rs
@@ -1,0 +1,141 @@
+use std::collections::HashMap;
+
+/// When Turborepo is configured with `"signature": true` (turbo.json), the CLI
+/// computes an HMAC-SHA256 of each artifact and sends it as the `x-artifact-tag`
+/// header on PUT. The server persists this value as S3 object metadata and returns
+/// it on GET so the client can verify artifact integrity. Without it, every
+/// download fails signature verification and is treated as a cache miss.
+/// See: https://turborepo.dev/api/remote-cache-spec
+pub const ARTIFACT_TAG_HEADER: &str = "x-artifact-tag";
+
+/// Turborepo sends the task run time on PUT and reads it back on GET and HEAD to
+/// report how much time the cache saved. Without it, every remote cache hit
+/// reports zero time saved.
+/// See: https://turborepo.dev/api/remote-cache-spec
+pub const ARTIFACT_DURATION_HEADER: &str = "x-artifact-duration";
+
+/// Identifies one artifact in the cache: the Turborepo hash, scoped by team.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactId {
+    pub team: String,
+    pub hash: String,
+}
+
+impl ArtifactId {
+    /// Object path as stored in the bucket.
+    pub fn object_path(&self) -> String {
+        format!("/{}/{}", self.team, self.hash)
+    }
+}
+
+/// The artifact headers Turborepo sends on upload and expects back on download.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ArtifactMetadata {
+    pub tag: Option<String>,
+    pub duration: Option<u64>,
+}
+
+impl ArtifactMetadata {
+    /// Reads the protocol key-value form. S3 metadata and HTTP headers share the keys.
+    pub fn from_key_values(mut map: HashMap<String, String>) -> Self {
+        Self {
+            tag: map.remove(ARTIFACT_TAG_HEADER),
+            duration: map
+                .remove(ARTIFACT_DURATION_HEADER)
+                .as_deref()
+                .and_then(parse_duration),
+        }
+    }
+
+    /// Writes the protocol key-value form.
+    pub fn into_key_values(self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+
+        if let Some(tag) = self.tag {
+            map.insert(ARTIFACT_TAG_HEADER.to_owned(), tag);
+        }
+
+        if let Some(duration) = self.duration {
+            map.insert(ARTIFACT_DURATION_HEADER.to_owned(), duration.to_string());
+        }
+
+        map
+    }
+}
+
+/// How much of a rejected duration reaches the log.
+const MAX_LOGGED_DURATION_CHARS: usize = 32;
+
+/// Turborepo fails the whole cache read on a duration it cannot parse, so a
+/// value the server cannot vouch for is dropped instead of passed on.
+pub(crate) fn parse_duration(raw: &str) -> Option<u64> {
+    match raw.parse::<u64>() {
+        Ok(duration) => Some(duration),
+        Err(_) => {
+            // A client picks this value and can repeat it on every request, so
+            // it stays off the warning path and never reaches the log in full.
+            let value: String = raw.chars().take(MAX_LOGGED_DURATION_CHARS).collect();
+            tracing::debug!(value = %value, "Ignoring malformed x-artifact-duration");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    const TAG: &str = "v=1:sha256:abc123";
+
+    #[test]
+    fn reads_both_artifact_headers_from_key_values() {
+        let stored = HashMap::from([
+            (ARTIFACT_TAG_HEADER.to_owned(), TAG.to_owned()),
+            (ARTIFACT_DURATION_HEADER.to_owned(), "1234".to_owned()),
+        ]);
+
+        assert_eq!(
+            ArtifactMetadata::from_key_values(stored),
+            ArtifactMetadata {
+                tag: Some(TAG.to_owned()),
+                duration: Some(1234),
+            }
+        );
+    }
+
+    /// Another writer may share the bucket, so the read path does not trust the
+    /// stored value either.
+    #[test]
+    fn drops_a_malformed_duration_from_key_values() {
+        let stored = HashMap::from([(
+            ARTIFACT_DURATION_HEADER.to_owned(),
+            "not-a-number".to_owned(),
+        )]);
+
+        assert_eq!(ArtifactMetadata::from_key_values(stored).duration, None);
+    }
+
+    #[test]
+    fn writes_the_duration_as_a_decimal_string() {
+        let metadata = ArtifactMetadata {
+            tag: None,
+            duration: Some(7),
+        };
+
+        assert_eq!(
+            metadata.into_key_values().get(ARTIFACT_DURATION_HEADER),
+            Some(&"7".to_owned())
+        );
+    }
+
+    #[test]
+    fn builds_the_object_path_from_team_and_hash() {
+        let id = ArtifactId {
+            team: "my-team".to_owned(),
+            hash: "abc123".to_owned(),
+        };
+
+        assert_eq!(id.object_path(), "/my-team/abc123");
+    }
+}

--- a/src/domain/error.rs
+++ b/src/domain/error.rs
@@ -1,0 +1,27 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum CacheError {
+    /// The store answered, but holds no artifact under that path.
+    NotFound,
+    /// The store could not be reached, or rejected the request.
+    StoreUnavailable(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl fmt::Display for CacheError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "no such artifact in the store"),
+            Self::StoreUnavailable(error) => write!(f, "store request failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CacheError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NotFound => None,
+            Self::StoreUnavailable(error) => Some(&**error),
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,5 @@
+pub mod artifact;
+pub mod error;
+
+pub use artifact::{ARTIFACT_DURATION_HEADER, ARTIFACT_TAG_HEADER, ArtifactId, ArtifactMetadata};
+pub use error::CacheError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_settings;
 pub mod auth;
+pub mod domain;
 pub mod http_span;
 pub mod routes;
 pub mod startup;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,3 +6,4 @@ pub mod routes;
 pub mod startup;
 pub mod storage;
 pub mod telemetry;
+pub mod usecases;

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -1,18 +1,25 @@
 use std::collections::HashMap;
+use std::fmt;
+use std::future::{Ready, ready};
 
 use actix_web::{
-    HttpRequest, HttpResponse, HttpResponseBuilder, Responder,
-    web::{Bytes, Data, Payload, Query},
+    FromRequest, HttpRequest, HttpResponse, HttpResponseBuilder, Responder, ResponseError, dev,
+    http::{Method, StatusCode},
+    web::{Data, Payload, Query},
 };
 use futures::StreamExt;
 use serde::Serialize;
 use tokio_util::io::StreamReader;
 
 use crate::domain::{
-    ARTIFACT_DURATION_HEADER, ARTIFACT_TAG_HEADER, ArtifactId, ArtifactMetadata,
+    ARTIFACT_DURATION_HEADER, ARTIFACT_TAG_HEADER, ArtifactId, ArtifactMetadata, CacheError,
     artifact::parse_duration,
 };
-use crate::storage::{Storage, StorageError};
+use crate::storage::Storage;
+use crate::usecases::ArtifactCache;
+
+/// The concrete cache the server wires up in `startup::run`.
+pub type Cache = ArtifactCache<Storage>;
 
 /// Reads the artifact headers from an upload request.
 fn metadata_from_headers(req: &HttpRequest) -> ArtifactMetadata {
@@ -36,6 +43,58 @@ fn apply_metadata_headers(metadata: &ArtifactMetadata, builder: &mut HttpRespons
 
     if let Some(duration) = metadata.duration {
         builder.insert_header((ARTIFACT_DURATION_HEADER, duration.to_string()));
+    }
+}
+
+/// Rejection for a request whose path holds no artifact hash.
+#[derive(Debug)]
+pub struct InvalidArtifactPath {
+    status: StatusCode,
+}
+
+impl fmt::Display for InvalidArtifactPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "request path holds no artifact hash")
+    }
+}
+
+impl ResponseError for InvalidArtifactPath {
+    fn status_code(&self) -> StatusCode {
+        self.status
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        HttpResponse::new(self.status)
+    }
+}
+
+impl FromRequest for ArtifactId {
+    type Error = InvalidArtifactPath;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut dev::Payload) -> Self::Future {
+        let id = req
+            .match_info()
+            .get("hash")
+            .filter(|hash| !hash.is_empty())
+            .map(|hash| ArtifactId {
+                team: extract_team_from_req(req),
+                hash: hash.to_owned(),
+            });
+
+        match id {
+            Some(id) => ready(Ok(id)),
+            // Matches the pre-refactor handlers: PUT answered 400, GET and HEAD 404.
+            None => {
+                let status = if req.method() == Method::PUT {
+                    StatusCode::BAD_REQUEST
+                } else {
+                    StatusCode::NOT_FOUND
+                };
+
+                ready(Err(InvalidArtifactPath { status }))
+            }
+        }
     }
 }
 
@@ -68,95 +127,55 @@ pub async fn post_list_team_artifacts(req: HttpRequest) -> impl Responder {
     HttpResponse::Ok().json(&EMPTY_HASHES)
 }
 
-#[tracing::instrument(name = "Check artifact", skip(req, storage))]
-pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl Responder {
-    let artifact_id = match artifact_id_from_req(&req) {
-        Some(id) => id,
-        None => return HttpResponse::NotFound().finish(),
-    };
+#[tracing::instrument(name = "Check artifact", skip(cache))]
+pub async fn head_check_file(
+    id: ArtifactId,
+    cache: Data<Cache>,
+) -> Result<HttpResponse, CacheError> {
+    let metadata = cache.check(&id).await?;
 
-    match storage.head_file(&artifact_id.object_path()).await {
-        Ok(metadata) => {
-            let mut builder = HttpResponse::Ok();
-            apply_metadata_headers(&ArtifactMetadata::from_key_values(metadata), &mut builder);
-            builder.finish()
-        }
-        Err(StorageError::NotFound) => HttpResponse::NotFound().finish(),
-        Err(error) => {
-            tracing::error!(error = %error, "Could not check artifact on the bucket");
-            HttpResponse::InternalServerError().finish()
-        }
-    }
+    let mut builder = HttpResponse::Ok();
+    apply_metadata_headers(&metadata, &mut builder);
+
+    Ok(builder.finish())
 }
 
-#[tracing::instrument(name = "Store artifact", skip(storage, body))]
-pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -> impl Responder {
-    let artifact_id = match artifact_id_from_req(&req) {
-        Some(id) => id,
-        None => return HttpResponse::BadRequest().finish(),
-    };
-
-    let metadata = metadata_from_headers(&req).into_key_values();
+#[tracing::instrument(name = "Store artifact", skip(req, cache, body))]
+pub async fn put_file(
+    req: HttpRequest,
+    id: ArtifactId,
+    cache: Data<Cache>,
+    body: Payload,
+) -> Result<HttpResponse, CacheError> {
+    let metadata = metadata_from_headers(&req);
 
     let io_stream = body.map(|chunk| chunk.map_err(std::io::Error::other));
     let mut reader = StreamReader::new(io_stream);
 
-    match storage
-        .put_file_stream(&artifact_id.object_path(), &mut reader, &metadata)
-        .await
-    {
-        Ok(_) => {
-            let artifact = Artifact {
-                filename: artifact_id.hash.clone(),
-            };
+    cache.store(&id, metadata, &mut reader).await?;
 
-            HttpResponse::Created().json(artifact)
-        }
-        Err(error) => {
-            tracing::error!(error = %error, "Could not store artifact on the bucket");
-            HttpResponse::InternalServerError().finish()
-        }
-    }
+    let artifact = Artifact {
+        filename: id.hash.clone(),
+    };
+
+    Ok(HttpResponse::Created().json(artifact))
 }
 
-#[tracing::instrument(name = "Read artifact", skip(storage))]
-pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responder {
-    let artifact_id = match artifact_id_from_req(&req) {
-        Some(id) => id,
-        None => return HttpResponse::NotFound().finish(),
-    };
+#[tracing::instrument(name = "Read artifact", skip(cache))]
+pub async fn get_file(id: ArtifactId, cache: Data<Cache>) -> Result<HttpResponse, CacheError> {
+    let (body, metadata) = cache.fetch(&id).await?;
 
-    let file_path = artifact_id.object_path();
-
-    let (maybe_response, metadata) = tokio::join!(
-        storage.get_file(&file_path),
-        storage.get_metadata(&file_path),
-    );
-
-    let response = match maybe_response {
-        Ok(response) => response,
-        Err(StorageError::NotFound) => return HttpResponse::NotFound().finish(),
-        Err(error) => {
-            tracing::error!(error = %error, "Could not read artifact from the bucket");
-            return HttpResponse::InternalServerError().finish();
-        }
-    };
-
-    let stream = response.bytes.map(|maybe_chunk| match maybe_chunk {
-        Ok(bytes) => Result::<Bytes, actix_web::error::Error>::Ok(bytes),
-        Err(error) => {
-            tracing::error!(error = error.to_string(), "Chunk stream error");
-            Result::<Bytes, actix_web::error::Error>::Err(
-                actix_web::error::ErrorInternalServerError("Error while streaming artifact"),
-            )
-        }
+    let stream = body.map(|maybe_chunk| {
+        maybe_chunk.map_err(|error| {
+            tracing::error!(error = %error, "Chunk stream error");
+            actix_web::error::ErrorInternalServerError("Error while streaming artifact")
+        })
     });
 
     let mut builder = HttpResponse::Ok();
+    apply_metadata_headers(&metadata, &mut builder);
 
-    apply_metadata_headers(&ArtifactMetadata::from_key_values(metadata), &mut builder);
-
-    builder.streaming(stream)
+    Ok(builder.streaming(stream))
 }
 
 fn extract_team_from_req(req: &HttpRequest) -> String {
@@ -167,13 +186,6 @@ fn extract_team_from_req(req: &HttpRequest) -> String {
         .or_else(|| query_string.get("teamId"))
         .unwrap_or(&default_team_name)
         .to_string()
-}
-
-fn artifact_id_from_req(req: &HttpRequest) -> Option<ArtifactId> {
-    let hash = req.match_info().get("hash")?.to_owned();
-    let team = extract_team_from_req(req);
-
-    Some(ArtifactId { team, hash })
 }
 
 const DUMMY_CACHE_STATUS: CacheStatus = CacheStatus { status: "enabled" };
@@ -237,5 +249,48 @@ mod tests {
             metadata.get(ARTIFACT_DURATION_HEADER).map(String::as_str),
             Some("7")
         );
+    }
+
+    #[tokio::test]
+    async fn extracts_the_artifact_id_from_path_and_query() {
+        let req = TestRequest::with_uri("/v8/artifacts/abc123?slug=my-team")
+            .param("hash", "abc123")
+            .to_http_request();
+
+        let id = ArtifactId::from_request(&req, &mut dev::Payload::None)
+            .await
+            .unwrap();
+
+        assert_eq!(id.team, "my-team");
+        assert_eq!(id.hash, "abc123");
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_no_team_without_a_team_query() {
+        let req = TestRequest::with_uri("/v8/artifacts/abc123")
+            .param("hash", "abc123")
+            .to_http_request();
+
+        let id = ArtifactId::from_request(&req, &mut dev::Payload::None)
+            .await
+            .unwrap();
+
+        assert_eq!(id.team, "no_team");
+    }
+
+    /// Matches the pre-refactor handlers: PUT answered 400, GET and HEAD 404.
+    #[tokio::test]
+    async fn rejects_a_missing_hash_with_the_method_status() {
+        let req = TestRequest::default().method(Method::PUT).to_http_request();
+        let error = ArtifactId::from_request(&req, &mut dev::Payload::None)
+            .await
+            .unwrap_err();
+        assert_eq!(error.status_code(), StatusCode::BAD_REQUEST);
+
+        let req = TestRequest::default().to_http_request();
+        let error = ArtifactId::from_request(&req, &mut dev::Payload::None)
+            .await
+            .unwrap_err();
+        assert_eq!(error.status_code(), StatusCode::NOT_FOUND);
     }
 }

--- a/src/routes/artifacts.rs
+++ b/src/routes/artifacts.rs
@@ -8,98 +8,34 @@ use futures::StreamExt;
 use serde::Serialize;
 use tokio_util::io::StreamReader;
 
+use crate::domain::{
+    ARTIFACT_DURATION_HEADER, ARTIFACT_TAG_HEADER, ArtifactId, ArtifactMetadata,
+    artifact::parse_duration,
+};
 use crate::storage::{Storage, StorageError};
 
-/// When Turborepo is configured with `"signature": true` (turbo.json), the CLI
-/// computes an HMAC-SHA256 of each artifact and sends it as the `x-artifact-tag`
-/// header on PUT. The server persists this value as S3 object metadata and returns
-/// it on GET so the client can verify artifact integrity. Without it, every
-/// download fails signature verification and is treated as a cache miss.
-/// See: https://turborepo.dev/api/remote-cache-spec
-const ARTIFACT_TAG_HEADER: &str = "x-artifact-tag";
+/// Reads the artifact headers from an upload request.
+fn metadata_from_headers(req: &HttpRequest) -> ArtifactMetadata {
+    let header = |name: &str| {
+        req.headers()
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+    };
 
-/// Turborepo sends the task run time on PUT and reads it back on GET and HEAD to
-/// report how much time the cache saved. Without it, every remote cache hit
-/// reports zero time saved.
-/// See: https://turborepo.dev/api/remote-cache-spec
-const ARTIFACT_DURATION_HEADER: &str = "x-artifact-duration";
-
-/// The artifact headers Turborepo sends on upload and expects back on download.
-/// They travel as S3 user metadata.
-#[derive(Debug, Default, PartialEq, Eq)]
-struct ArtifactMetadata {
-    tag: Option<String>,
-    duration: Option<u64>,
-}
-
-impl ArtifactMetadata {
-    /// Reads the artifact headers from an upload request.
-    fn from_request(req: &HttpRequest) -> Self {
-        let header = |name: &str| {
-            req.headers()
-                .get(name)
-                .and_then(|value| value.to_str().ok())
-        };
-
-        Self {
-            tag: header(ARTIFACT_TAG_HEADER).map(str::to_owned),
-            duration: header(ARTIFACT_DURATION_HEADER).and_then(parse_duration),
-        }
-    }
-
-    /// Reads the artifact headers from the metadata stored on the S3 object.
-    fn from_storage(mut metadata: HashMap<String, String>) -> Self {
-        Self {
-            tag: metadata.remove(ARTIFACT_TAG_HEADER),
-            duration: metadata
-                .remove(ARTIFACT_DURATION_HEADER)
-                .as_deref()
-                .and_then(parse_duration),
-        }
-    }
-
-    /// The key-value pairs to persist as S3 user metadata.
-    fn into_storage(self) -> HashMap<String, String> {
-        let mut metadata = HashMap::new();
-
-        if let Some(tag) = self.tag {
-            metadata.insert(ARTIFACT_TAG_HEADER.to_owned(), tag);
-        }
-
-        if let Some(duration) = self.duration {
-            metadata.insert(ARTIFACT_DURATION_HEADER.to_owned(), duration.to_string());
-        }
-
-        metadata
-    }
-
-    /// Copies the artifact headers onto a download response.
-    fn apply(&self, builder: &mut HttpResponseBuilder) {
-        if let Some(tag) = &self.tag {
-            builder.insert_header((ARTIFACT_TAG_HEADER, tag.as_str()));
-        }
-
-        if let Some(duration) = self.duration {
-            builder.insert_header((ARTIFACT_DURATION_HEADER, duration.to_string()));
-        }
+    ArtifactMetadata {
+        tag: header(ARTIFACT_TAG_HEADER).map(str::to_owned),
+        duration: header(ARTIFACT_DURATION_HEADER).and_then(parse_duration),
     }
 }
 
-/// How much of a rejected duration reaches the log.
-const MAX_LOGGED_DURATION_CHARS: usize = 32;
+/// Copies the artifact headers onto a download response.
+fn apply_metadata_headers(metadata: &ArtifactMetadata, builder: &mut HttpResponseBuilder) {
+    if let Some(tag) = &metadata.tag {
+        builder.insert_header((ARTIFACT_TAG_HEADER, tag.as_str()));
+    }
 
-/// Turborepo fails the whole cache read on a duration it cannot parse, so a
-/// value the server cannot vouch for is dropped instead of passed on.
-fn parse_duration(raw: &str) -> Option<u64> {
-    match raw.parse::<u64>() {
-        Ok(duration) => Some(duration),
-        Err(_) => {
-            // A client picks this value and can repeat it on every request, so
-            // it stays off the warning path and never reaches the log in full.
-            let value: String = raw.chars().take(MAX_LOGGED_DURATION_CHARS).collect();
-            tracing::debug!(value = %value, "Ignoring malformed x-artifact-duration");
-            None
-        }
+    if let Some(duration) = metadata.duration {
+        builder.insert_header((ARTIFACT_DURATION_HEADER, duration.to_string()));
     }
 }
 
@@ -134,15 +70,15 @@ pub async fn post_list_team_artifacts(req: HttpRequest) -> impl Responder {
 
 #[tracing::instrument(name = "Check artifact", skip(req, storage))]
 pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl Responder {
-    let artifact_info = match ArtifactRequest::from(&req) {
-        Some(info) => info,
+    let artifact_id = match artifact_id_from_req(&req) {
+        Some(id) => id,
         None => return HttpResponse::NotFound().finish(),
     };
 
-    match storage.head_file(&artifact_info.file_path()).await {
+    match storage.head_file(&artifact_id.object_path()).await {
         Ok(metadata) => {
             let mut builder = HttpResponse::Ok();
-            ArtifactMetadata::from_storage(metadata).apply(&mut builder);
+            apply_metadata_headers(&ArtifactMetadata::from_key_values(metadata), &mut builder);
             builder.finish()
         }
         Err(StorageError::NotFound) => HttpResponse::NotFound().finish(),
@@ -155,23 +91,23 @@ pub async fn head_check_file(req: HttpRequest, storage: Data<Storage>) -> impl R
 
 #[tracing::instrument(name = "Store artifact", skip(storage, body))]
 pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -> impl Responder {
-    let artifact_info = match ArtifactRequest::from(&req) {
-        Some(info) => info,
+    let artifact_id = match artifact_id_from_req(&req) {
+        Some(id) => id,
         None => return HttpResponse::BadRequest().finish(),
     };
 
-    let metadata = ArtifactMetadata::from_request(&req).into_storage();
+    let metadata = metadata_from_headers(&req).into_key_values();
 
     let io_stream = body.map(|chunk| chunk.map_err(std::io::Error::other));
     let mut reader = StreamReader::new(io_stream);
 
     match storage
-        .put_file_stream(&artifact_info.file_path(), &mut reader, &metadata)
+        .put_file_stream(&artifact_id.object_path(), &mut reader, &metadata)
         .await
     {
         Ok(_) => {
             let artifact = Artifact {
-                filename: artifact_info.hash.clone(),
+                filename: artifact_id.hash.clone(),
             };
 
             HttpResponse::Created().json(artifact)
@@ -185,12 +121,12 @@ pub async fn put_file(req: HttpRequest, storage: Data<Storage>, body: Payload) -
 
 #[tracing::instrument(name = "Read artifact", skip(storage))]
 pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responder {
-    let artifact_info = match ArtifactRequest::from(&req) {
-        Some(info) => info,
+    let artifact_id = match artifact_id_from_req(&req) {
+        Some(id) => id,
         None => return HttpResponse::NotFound().finish(),
     };
 
-    let file_path = artifact_info.file_path();
+    let file_path = artifact_id.object_path();
 
     let (maybe_response, metadata) = tokio::join!(
         storage.get_file(&file_path),
@@ -218,7 +154,7 @@ pub async fn get_file(req: HttpRequest, storage: Data<Storage>) -> impl Responde
 
     let mut builder = HttpResponse::Ok();
 
-    ArtifactMetadata::from_storage(metadata).apply(&mut builder);
+    apply_metadata_headers(&ArtifactMetadata::from_key_values(metadata), &mut builder);
 
     builder.streaming(stream)
 }
@@ -233,27 +169,11 @@ fn extract_team_from_req(req: &HttpRequest) -> String {
         .to_string()
 }
 
-struct ArtifactRequest {
-    hash: String,
-    team: String,
-}
+fn artifact_id_from_req(req: &HttpRequest) -> Option<ArtifactId> {
+    let hash = req.match_info().get("hash")?.to_owned();
+    let team = extract_team_from_req(req);
 
-impl ArtifactRequest {
-    /// File path as represented in the S3 storage
-    fn file_path(&self) -> String {
-        format!("/{}/{}", self.team, self.hash)
-    }
-
-    fn from(req: &HttpRequest) -> Option<Self> {
-        let hash = {
-            let h = req.match_info().get("hash")?;
-            h.to_owned()
-        };
-
-        let team = extract_team_from_req(req);
-
-        Some(ArtifactRequest { hash, team })
-    }
+    Some(ArtifactId { team, hash })
 }
 
 const DUMMY_CACHE_STATUS: CacheStatus = CacheStatus { status: "enabled" };
@@ -278,7 +198,7 @@ mod tests {
             .to_http_request();
 
         assert_eq!(
-            ArtifactMetadata::from_request(&req),
+            metadata_from_headers(&req),
             ArtifactMetadata {
                 tag: Some(TAG.to_owned()),
                 duration: Some(1234),
@@ -290,10 +210,7 @@ mod tests {
     fn reads_no_artifact_headers_from_a_bare_request() {
         let req = TestRequest::default().to_http_request();
 
-        assert_eq!(
-            ArtifactMetadata::from_request(&req),
-            ArtifactMetadata::default()
-        );
+        assert_eq!(metadata_from_headers(&req), ArtifactMetadata::default());
     }
 
     /// Turborepo fails the whole cache read on a duration it cannot parse, so a
@@ -304,7 +221,7 @@ mod tests {
             .insert_header((ARTIFACT_DURATION_HEADER, "not-a-number"))
             .to_http_request();
 
-        assert_eq!(ArtifactMetadata::from_request(&req).duration, None);
+        assert_eq!(metadata_from_headers(&req).duration, None);
     }
 
     /// The bucket holds the parsed number, not the bytes the client sent.
@@ -314,39 +231,11 @@ mod tests {
             .insert_header((ARTIFACT_DURATION_HEADER, "007"))
             .to_http_request();
 
-        let metadata = ArtifactMetadata::from_request(&req).into_storage();
+        let metadata = metadata_from_headers(&req).into_key_values();
 
         assert_eq!(
             metadata.get(ARTIFACT_DURATION_HEADER).map(String::as_str),
             Some("7")
         );
-    }
-
-    #[test]
-    fn reads_both_artifact_headers_from_storage() {
-        let stored = HashMap::from([
-            (ARTIFACT_TAG_HEADER.to_owned(), TAG.to_owned()),
-            (ARTIFACT_DURATION_HEADER.to_owned(), "1234".to_owned()),
-        ]);
-
-        assert_eq!(
-            ArtifactMetadata::from_storage(stored),
-            ArtifactMetadata {
-                tag: Some(TAG.to_owned()),
-                duration: Some(1234),
-            }
-        );
-    }
-
-    /// Another writer may share the bucket, so the read path does not trust the
-    /// stored value either.
-    #[test]
-    fn drops_a_malformed_duration_from_storage() {
-        let stored = HashMap::from([(
-            ARTIFACT_DURATION_HEADER.to_owned(),
-            "not-a-number".to_owned(),
-        )]);
-
-        assert_eq!(ArtifactMetadata::from_storage(stored).duration, None);
     }
 }

--- a/src/routes/error.rs
+++ b/src/routes/error.rs
@@ -1,0 +1,22 @@
+use actix_web::{HttpResponse, ResponseError, http::StatusCode};
+
+use crate::domain::CacheError;
+
+/// The only place where `CacheError` meets HTTP.
+impl ResponseError for CacheError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            CacheError::NotFound => StatusCode::NOT_FOUND,
+            CacheError::StoreUnavailable(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        if let CacheError::StoreUnavailable(error) = self {
+            tracing::error!(error = %error, "Storage request failed");
+        }
+
+        // Status code with an empty body, matching the pre-refactor handlers.
+        HttpResponse::new(self.status_code())
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod artifacts;
+pub mod error;
 pub mod events;
 pub mod health_check;
 

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -17,11 +17,12 @@ use crate::{
         post_list_team_artifacts, put_file,
     },
     storage::Storage,
+    usecases::ArtifactCache,
 };
 
 pub fn run(listener: TcpListener, app_settings: AppSettings) -> Result<Server, std::io::Error> {
-    let storage = Storage::new(&app_settings);
-    let storage = web::Data::new(storage);
+    let cache = ArtifactCache::new(Storage::new(&app_settings));
+    let cache = web::Data::new(cache);
     let port = listener
         .local_addr()
         .expect("TCPListener should be valid")
@@ -46,7 +47,7 @@ pub fn run(listener: TcpListener, app_settings: AppSettings) -> Result<Server, s
             .route(HEALTH_CHECK_PATH, web::get().to(health_check))
             .service(artifacts_scope)
             .app_data(app_settings.clone())
-            .app_data(storage.clone())
+            .app_data(cache.clone())
     })
     .listen(listener)?
     .run();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 
 use bytes::Bytes;
 use futures::Stream;
-use s3::{Bucket, Region, creds::Credentials, error::S3Error, request::ResponseDataStream};
+use s3::{Bucket, Region, creds::Credentials, error::S3Error};
 use secrecy::ExposeSecret;
 use tokio::io::AsyncRead;
 
@@ -13,41 +13,6 @@ use crate::domain::CacheError;
 use crate::usecases::ArtifactStore;
 
 const SSE_HEADER: http::HeaderName = http::HeaderName::from_static("x-amz-server-side-encryption");
-
-#[derive(Debug)]
-pub enum StorageError {
-    /// The bucket answered, but holds no object under that path.
-    NotFound,
-    /// The bucket could not be reached, or rejected the request.
-    Unreachable(S3Error),
-}
-
-impl fmt::Display for StorageError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NotFound => write!(f, "no such object in the bucket"),
-            Self::Unreachable(error) => write!(f, "S3 request failed: {error}"),
-        }
-    }
-}
-
-impl std::error::Error for StorageError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::NotFound => None,
-            Self::Unreachable(error) => Some(error),
-        }
-    }
-}
-
-impl From<S3Error> for StorageError {
-    fn from(error: S3Error) -> Self {
-        match error {
-            S3Error::HttpFailWithBody(404, _) => Self::NotFound,
-            other => Self::Unreachable(other),
-        }
-    }
-}
 
 impl From<S3Error> for CacheError {
     fn from(error: S3Error) -> Self {
@@ -112,66 +77,6 @@ impl Storage {
             bucket,
             server_side_encryption: settings.s3_server_side_encryption,
         }
-    }
-
-    /// Streams the file from the S3 bucket
-    #[tracing::instrument(name = "get S3 file")]
-    pub async fn get_file(&self, path: &str) -> Result<ResponseDataStream, StorageError> {
-        let file = self.bucket.get_object_stream(path).await?;
-        Ok(file)
-    }
-
-    /// Returns the user metadata stored on the S3 object, or reports that the
-    /// object is missing.
-    #[tracing::instrument(name = "head S3 file")]
-    pub async fn head_file(&self, path: &str) -> Result<HashMap<String, String>, StorageError> {
-        let (head_result, _status) = self.bucket.head_object(path).await?;
-        Ok(head_result.metadata.unwrap_or_default())
-    }
-
-    /// Returns the user metadata stored on the S3 object.
-    /// A failed lookup must not fail an otherwise good download, so it reports
-    /// no metadata rather than an error.
-    #[tracing::instrument(name = "get S3 object metadata")]
-    pub async fn get_metadata(&self, path: &str) -> HashMap<String, String> {
-        match self.head_file(path).await {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                tracing::warn!(error = %error, path, "HEAD request failed, omitting object metadata");
-                HashMap::new()
-            }
-        }
-    }
-
-    /// Streams the given data to the S3 bucket under the given path.
-    /// Each metadata key-value pair is persisted as S3 user metadata
-    /// (x-amz-meta-*) so it can be retrieved on subsequent HEADs.
-    #[tracing::instrument(name = "put S3 file stream", skip(reader))]
-    pub async fn put_file_stream<R>(
-        &self,
-        path: &str,
-        reader: &mut R,
-        metadata: &HashMap<String, String>,
-    ) -> Result<(), StorageError>
-    where
-        R: AsyncRead + Unpin,
-    {
-        let mut builder = self.bucket.put_object_stream_builder(path);
-
-        if let Some(encryption) = self.server_side_encryption {
-            builder = builder
-                .with_header(SSE_HEADER, encryption.as_str())
-                .expect("Invalid server-side encryption header value");
-        }
-
-        for (key, value) in metadata {
-            builder = builder
-                .with_metadata(key, value)
-                .expect("Invalid metadata value");
-        }
-
-        builder.execute_stream(reader).await?;
-        Ok(())
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::pin::Pin;
 
+use bytes::Bytes;
+use futures::Stream;
 use s3::{Bucket, Region, creds::Credentials, error::S3Error, request::ResponseDataStream};
 use secrecy::ExposeSecret;
 use tokio::io::AsyncRead;
 
 use crate::app_settings::{AppSettings, S3ServerSideEncryption};
+use crate::domain::CacheError;
+use crate::usecases::ArtifactStore;
 
 const SSE_HEADER: http::HeaderName = http::HeaderName::from_static("x-amz-server-side-encryption");
 
@@ -40,6 +45,15 @@ impl From<S3Error> for StorageError {
         match error {
             S3Error::HttpFailWithBody(404, _) => Self::NotFound,
             other => Self::Unreachable(other),
+        }
+    }
+}
+
+impl From<S3Error> for CacheError {
+    fn from(error: S3Error) -> Self {
+        match error {
+            S3Error::HttpFailWithBody(404, _) => Self::NotFound,
+            other => Self::StoreUnavailable(Box::new(other)),
         }
     }
 }
@@ -161,9 +175,69 @@ impl Storage {
     }
 }
 
+impl ArtifactStore for Storage {
+    // The s3 crate already returns its stream boxed; this adds no boxing.
+    type ByteStream = Pin<Box<dyn Stream<Item = Result<Bytes, S3Error>> + Send>>;
+    type StreamError = S3Error;
+
+    #[tracing::instrument(name = "get S3 file")]
+    async fn get(&self, path: &str) -> Result<Self::ByteStream, CacheError> {
+        let response = self
+            .bucket
+            .get_object_stream(path)
+            .await
+            .map_err(CacheError::from)?;
+        Ok(response.bytes)
+    }
+
+    #[tracing::instrument(name = "head S3 file")]
+    async fn head(&self, path: &str) -> Result<HashMap<String, String>, CacheError> {
+        let (head_result, _status) = self
+            .bucket
+            .head_object(path)
+            .await
+            .map_err(CacheError::from)?;
+        Ok(head_result.metadata.unwrap_or_default())
+    }
+
+    /// Each metadata key-value pair is persisted as S3 user metadata
+    /// (x-amz-meta-*) so it can be retrieved on subsequent HEADs.
+    #[tracing::instrument(name = "put S3 file stream", skip(reader, metadata))]
+    async fn put<R>(
+        &self,
+        path: &str,
+        reader: &mut R,
+        metadata: HashMap<String, String>,
+    ) -> Result<(), CacheError>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut builder = self.bucket.put_object_stream_builder(path);
+
+        if let Some(encryption) = self.server_side_encryption {
+            builder = builder
+                .with_header(SSE_HEADER, encryption.as_str())
+                .expect("Invalid server-side encryption header value");
+        }
+
+        for (key, value) in &metadata {
+            builder = builder
+                .with_metadata(key, value)
+                .expect("Invalid metadata value");
+        }
+
+        builder
+            .execute_stream(reader)
+            .await
+            .map_err(CacheError::from)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::CacheError;
 
     fn settings_with_credentials() -> AppSettings {
         AppSettings {
@@ -189,5 +263,22 @@ mod tests {
 
         assert!(!debug_output.contains("super-secret-access-key"));
         assert!(!debug_output.contains("super-secret-secret-key"));
+    }
+
+    #[test]
+    fn maps_a_404_to_not_found() {
+        let error = S3Error::HttpFailWithBody(404, "no such key".to_owned());
+
+        assert!(matches!(CacheError::from(error), CacheError::NotFound));
+    }
+
+    #[test]
+    fn maps_other_failures_to_store_unavailable() {
+        let error = S3Error::HttpFailWithBody(500, "boom".to_owned());
+
+        assert!(matches!(
+            CacheError::from(error),
+            CacheError::StoreUnavailable(_)
+        ));
     }
 }

--- a/src/usecases/artifact_cache.rs
+++ b/src/usecases/artifact_cache.rs
@@ -1,0 +1,226 @@
+use tokio::io::AsyncRead;
+
+use crate::domain::{ArtifactId, ArtifactMetadata, CacheError};
+
+use super::ArtifactStore;
+
+/// The artifact cache use-cases: store, fetch, and check artifacts.
+pub struct ArtifactCache<S: ArtifactStore> {
+    store: S,
+}
+
+impl<S: ArtifactStore> ArtifactCache<S> {
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    /// Stores the artifact body with its metadata.
+    pub async fn store<R>(
+        &self,
+        id: &ArtifactId,
+        metadata: ArtifactMetadata,
+        reader: &mut R,
+    ) -> Result<(), CacheError>
+    where
+        R: AsyncRead + Unpin,
+    {
+        self.store
+            .put(&id.object_path(), reader, metadata.into_key_values())
+            .await
+    }
+
+    /// Returns the artifact body stream and its metadata.
+    pub async fn fetch(
+        &self,
+        id: &ArtifactId,
+    ) -> Result<(S::ByteStream, ArtifactMetadata), CacheError> {
+        let path = id.object_path();
+
+        let (body, metadata) = tokio::join!(self.store.get(&path), self.store.head(&path));
+
+        let metadata = match metadata {
+            Ok(map) => ArtifactMetadata::from_key_values(map),
+            // A failed metadata lookup must not fail an otherwise good download.
+            Err(error) => {
+                tracing::warn!(error = %error, path, "Metadata lookup failed, omitting artifact metadata");
+                ArtifactMetadata::default()
+            }
+        };
+
+        Ok((body?, metadata))
+    }
+
+    /// Returns the artifact metadata, or `NotFound`.
+    pub async fn check(&self, id: &ArtifactId) -> Result<ArtifactMetadata, CacheError> {
+        let map = self.store.head(&id.object_path()).await?;
+
+        Ok(ArtifactMetadata::from_key_values(map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::convert::Infallible;
+    use std::sync::Mutex;
+
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use pretty_assertions::assert_eq;
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+
+    /// In-memory `ArtifactStore` with switches to force each read path to fail.
+    #[derive(Default)]
+    #[allow(clippy::type_complexity)]
+    struct InMemoryStore {
+        objects: Mutex<HashMap<String, (Vec<u8>, HashMap<String, String>)>>,
+        fail_get: bool,
+        fail_head: bool,
+    }
+
+    impl ArtifactStore for InMemoryStore {
+        type ByteStream = futures::stream::Iter<std::vec::IntoIter<Result<Bytes, Infallible>>>;
+        type StreamError = Infallible;
+
+        async fn get(&self, path: &str) -> Result<Self::ByteStream, CacheError> {
+            if self.fail_get {
+                return Err(CacheError::StoreUnavailable("get switched off".into()));
+            }
+
+            let objects = self.objects.lock().unwrap();
+            let (bytes, _) = objects.get(path).ok_or(CacheError::NotFound)?;
+
+            Ok(futures::stream::iter(vec![Ok(Bytes::from(bytes.clone()))]))
+        }
+
+        async fn head(&self, path: &str) -> Result<HashMap<String, String>, CacheError> {
+            if self.fail_head {
+                return Err(CacheError::StoreUnavailable("head switched off".into()));
+            }
+
+            let objects = self.objects.lock().unwrap();
+            let (_, metadata) = objects.get(path).ok_or(CacheError::NotFound)?;
+
+            Ok(metadata.clone())
+        }
+
+        async fn put<R>(
+            &self,
+            path: &str,
+            reader: &mut R,
+            metadata: HashMap<String, String>,
+        ) -> Result<(), CacheError>
+        where
+            R: AsyncRead + Unpin,
+        {
+            let mut buffer = Vec::new();
+            reader
+                .read_to_end(&mut buffer)
+                .await
+                .expect("in-memory read cannot fail");
+
+            self.objects
+                .lock()
+                .unwrap()
+                .insert(path.to_owned(), (buffer, metadata));
+
+            Ok(())
+        }
+    }
+
+    fn artifact_id() -> ArtifactId {
+        ArtifactId {
+            team: "my-team".to_owned(),
+            hash: "abc123".to_owned(),
+        }
+    }
+
+    async fn read_body(
+        stream: futures::stream::Iter<std::vec::IntoIter<Result<Bytes, Infallible>>>,
+    ) -> Vec<u8> {
+        let chunks: Vec<Result<Bytes, Infallible>> = stream.collect().await;
+        chunks
+            .into_iter()
+            .flat_map(|chunk| chunk.unwrap())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn check_reports_not_found_for_a_missing_artifact() {
+        let cache = ArtifactCache::new(InMemoryStore::default());
+
+        let result = cache.check(&artifact_id()).await;
+
+        assert!(matches!(result, Err(CacheError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn fetch_reports_not_found_for_a_missing_artifact() {
+        let cache = ArtifactCache::new(InMemoryStore::default());
+
+        let result = cache.fetch(&artifact_id()).await;
+
+        assert!(matches!(result, Err(CacheError::NotFound)));
+    }
+
+    #[tokio::test]
+    async fn body_and_metadata_round_trip_through_store_and_fetch() {
+        let cache = ArtifactCache::new(InMemoryStore::default());
+        let metadata = ArtifactMetadata {
+            tag: Some("v=1:sha256:abc123".to_owned()),
+            duration: Some(42),
+        };
+
+        let mut reader = &b"artifact-bytes"[..];
+        cache
+            .store(&artifact_id(), metadata, &mut reader)
+            .await
+            .unwrap();
+
+        let (body, fetched) = cache.fetch(&artifact_id()).await.unwrap();
+
+        assert_eq!(
+            fetched,
+            ArtifactMetadata {
+                tag: Some("v=1:sha256:abc123".to_owned()),
+                duration: Some(42),
+            }
+        );
+        assert_eq!(read_body(body).await, b"artifact-bytes");
+    }
+
+    /// A failed metadata lookup must not fail an otherwise good download.
+    #[tokio::test]
+    async fn fetch_returns_empty_metadata_when_the_metadata_lookup_fails() {
+        let store = InMemoryStore {
+            fail_head: true,
+            ..Default::default()
+        };
+        store.objects.lock().unwrap().insert(
+            artifact_id().object_path(),
+            (b"artifact-bytes".to_vec(), HashMap::new()),
+        );
+        let cache = ArtifactCache::new(store);
+
+        let (body, metadata) = cache.fetch(&artifact_id()).await.unwrap();
+
+        assert_eq!(metadata, ArtifactMetadata::default());
+        assert_eq!(read_body(body).await, b"artifact-bytes");
+    }
+
+    #[tokio::test]
+    async fn store_writes_under_the_artifact_object_path() {
+        let cache = ArtifactCache::new(InMemoryStore::default());
+
+        let mut reader = &b"artifact-bytes"[..];
+        cache
+            .store(&artifact_id(), ArtifactMetadata::default(), &mut reader)
+            .await
+            .unwrap();
+
+        let objects = cache.store.objects.lock().unwrap();
+        assert!(objects.contains_key("/my-team/abc123"));
+    }
+}

--- a/src/usecases/mod.rs
+++ b/src/usecases/mod.rs
@@ -1,0 +1,5 @@
+pub mod artifact_cache;
+pub mod store;
+
+pub use artifact_cache::ArtifactCache;
+pub use store::ArtifactStore;

--- a/src/usecases/store.rs
+++ b/src/usecases/store.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+use futures::Stream;
+use tokio::io::AsyncRead;
+
+use crate::domain::CacheError;
+
+/// The storage port. `ArtifactCache` reaches any artifact store through this
+/// trait. `storage::Storage` is the S3 implementation; tests use an in-memory one.
+///
+/// This crate's own handlers run on the actix runtime and need no `Send`
+/// futures, so callers outside this crate get no `Send` guarantee either.
+#[allow(async_fn_in_trait)]
+pub trait ArtifactStore: Send + Sync + 'static {
+    /// The artifact body as a stream of byte chunks.
+    type ByteStream: Stream<Item = Result<bytes::Bytes, Self::StreamError>> + Unpin;
+    type StreamError: std::error::Error;
+
+    /// Returns the artifact body stream.
+    async fn get(&self, path: &str) -> Result<Self::ByteStream, CacheError>;
+
+    /// Returns the key-value metadata stored with the artifact.
+    async fn head(&self, path: &str) -> Result<HashMap<String, String>, CacheError>;
+
+    /// Writes the artifact body and its key-value metadata.
+    async fn put<R>(
+        &self,
+        path: &str,
+        reader: &mut R,
+        metadata: HashMap<String, String>,
+    ) -> Result<(), CacheError>
+    where
+        R: AsyncRead + Unpin;
+}


### PR DESCRIPTION
## What

Splits the server into four layers. Routes now only translate HTTP. The business logic lives in a use-case.

- `src/domain/` — `ArtifactId`, `ArtifactMetadata`, `CacheError`, and the protocol parsing rules. No actix or S3 imports.
- `src/usecases/` — the `ArtifactStore` trait (the port) and `ArtifactCache<S>` with the store / fetch / check use-cases. Unit-tested against an in-memory store.
- `src/storage.rs` — implements `ArtifactStore` for S3. The old inherent methods and `StorageError` are gone.
- `src/routes/` — thin handlers. `ArtifactId` is an actix extractor. `routes/error.rs` is the one place `CacheError` maps to HTTP status codes.

## Why

Business logic kept growing inside `routes/artifacts.rs`: metadata parsing, object path building, and the metadata-failure policy all lived next to HTTP plumbing. Now each rule has one home, and the use-case layer is testable without S3.

One rule became explicit and tested: a failed metadata lookup must not fail a good download. It used to hide inside `Storage::get_metadata`; it now lives in `ArtifactCache::fetch` with a unit test.

## No behavior change

Every endpoint returns the same status codes, headers, and bodies. The e2e suite passes with zero edits — that is the proof. 47 unit + 28 e2e tests pass; clippy reports no new warnings.

Design doc: `docs/superpowers/specs/2026-08-23-layered-architecture-design.md` (local, gitignored).